### PR TITLE
ci(windows): check whether package can be installed

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,6 +24,7 @@ jobs:
           - { os: "macos", r: "release", platform: "metal" }
           - { os: "ubuntu", r: "release", platform: "cpu" }
           - { os: "ubuntu", r: "release", platform: "cuda"}
+          - { os: "windows", r: "release", platform: "cpu"}
 
         include:
           - config: {os: "ubuntu", platform: "cuda"}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -10,4 +10,7 @@ library(testthat)
 library(checkmate)
 library(pjrt)
 
-test_check("pjrt")
+# skip on windows
+if (!Sys.info()["sysname"] == "Windows") {
+  test_check("pjrt", reporter = "summary")
+}


### PR DESCRIPTION
Not really adding windows support (yet), just check whether it can be installed