### PR TITLE
Bump xla headers version

### DIFF
--- a/R/plugin.R
+++ b/R/plugin.R
@@ -37,6 +37,12 @@ pjrt_plugin <- function(platform) {
 }
 
 plugin_path <- function(platform) {
+
+  envvar <- Sys.getenv(paste0("PJRT_PLUGIN_PATH_", toupper(platform)), "")
+  if (envvar != "") {
+    return(envvar)
+  }
+
   cache_dir <- tools::R_user_dir("pjrt", which = "cache")
 
   platform_cache_dir <- file.path(cache_dir, platform)
@@ -127,7 +133,7 @@ plugin_version <- function() {
     return(Sys.getenv("PJRT_ZML_ARTIFACT_VERSION"))
   }
 
-  "9.0.1"
+  "11.0.0"
 }
 
 plugin_os <- function() {

--- a/inst/include/xla/pjrt/c/pjrt_c_api.h
+++ b/inst/include/xla/pjrt/c/pjrt_c_api.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_PJRT_C_PJRT_C_API_H_
 #define XLA_PJRT_C_PJRT_C_API_H_
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -26,11 +27,24 @@ limitations under the License.
 #define PJRT_STRUCT_SIZE(struct_type, last_field) \
   offsetof(struct_type, last_field) + sizeof(((struct_type*)0)->last_field)
 
+#ifdef __cplusplus
+#define PJRT_CHECK_STRUCT_SIZE(sname, last_field)                       \
+  static_assert(                                                        \
+      sizeof(struct sname) ==                                           \
+          ((PJRT_STRUCT_SIZE(sname, last_field) + alignof(sname) - 1) / \
+           alignof(sname)) *                                            \
+              alignof(sname),                                           \
+      "Failed to update last_field");
+#else
+#define PJRT_CHECK_STRUCT_SIZE(sname, last_field)
+#endif
+
 // Must update PJRT_DEFINE_STRUCT_TRAITS with the new `last_field` after
 // adding a new member to a struct.
-#define PJRT_DEFINE_STRUCT_TRAITS(sname, last_field) \
-  typedef struct sname sname;                        \
-  enum { sname##_STRUCT_SIZE = PJRT_STRUCT_SIZE(sname, last_field) }
+#define PJRT_DEFINE_STRUCT_TRAITS(sname, last_field)                  \
+  typedef struct sname sname;                                         \
+  enum { sname##_STRUCT_SIZE = PJRT_STRUCT_SIZE(sname, last_field) }; \
+  PJRT_CHECK_STRUCT_SIZE(sname, last_field)
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,7 +61,11 @@ typedef enum {
   PJRT_Extension_Type_FFI,
   PJRT_Extension_Type_MemoryDescriptions,
   PJRT_Extension_Type_Triton,
-  PJRT_Extension_Type_RawBuffer,  // Experimental.
+  PJRT_Extension_Type_RawBuffer,     // Experimental.
+  PJRT_Extension_Type_PhaseCompile,  // Experimental.
+  PJRT_Extension_Type_Example,
+  PJRT_Extension_Type_Unknown,
+  PJRT_Extension_Type_CrossHostTransfers,
 } PJRT_Extension_Type;
 
 // PJRT_Extension_Base contains a type and a pointer to next
@@ -82,7 +100,7 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Extension_Base, next);
 // Changes include:
 // * Adding a new field to the PJRT_Api or argument structs
 // * Renaming a method or argument (doesn't affect ABI)
-#define PJRT_API_MINOR 69
+#define PJRT_API_MINOR 74
 
 // The plugin should set the major_version and minor_version of
 // PJRT_Api.pjrt_api_version to be the `PJRT_API_MAJOR` and `PJRT_API_MINOR` in
@@ -208,19 +226,19 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Plugin_Initialize_Args, extension_start);
 // One-time plugin setup. Must be called before any other functions are called.
 typedef PJRT_Error* PJRT_Plugin_Initialize(PJRT_Plugin_Initialize_Args* args);
 
-struct plugin_attributes_Args {
+struct PJRT_Plugin_Attributes_Args {
   size_t struct_size;
   PJRT_Extension_Base* extension_start;
   // Returned attributes have the lifetime of the process.
   const PJRT_NamedValue* attributes;  // out
   size_t num_attributes;              // out
 };
-PJRT_DEFINE_STRUCT_TRAITS(plugin_attributes_Args, attributes);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Plugin_Attributes_Args, num_attributes);
 
 // Returns an array of plugin attributes which are key-value pairs. Common keys
 // include `xla_version`, `stablehlo_current_version`, and
 // `stablehlo_minimum_version`.
-typedef PJRT_Error* plugin_attributes(plugin_attributes_Args* args);
+typedef PJRT_Error* PJRT_Plugin_Attributes(PJRT_Plugin_Attributes_Args* args);
 
 // ---------------------------------- Events -----------------------------------
 
@@ -318,6 +336,7 @@ typedef struct PJRT_LoadedExecutable PJRT_LoadedExecutable;
 typedef struct PJRT_Buffer PJRT_Buffer;
 typedef struct PJRT_AsyncHostToDeviceTransferManager
     PJRT_AsyncHostToDeviceTransferManager;
+typedef struct PJRT_PhaseCompiler PJRT_PhaseCompiler;
 
 // The caller of PJRT_Client_Create can optionally provide a key-value store
 // accessible across nodes and/or processes. KV store access may be necessary to
@@ -561,6 +580,45 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_LookupAddressableDevice_Args,
 // PJRT_DeviceDescription_LocalHardwareId.
 typedef PJRT_Error* PJRT_Client_LookupAddressableDevice(
     PJRT_Client_LookupAddressableDevice_Args* args);
+
+typedef enum {
+  PJRT_ProcessState_kUnspecified = 0,
+  PJRT_ProcessState_kUninitialized = 1,
+  PJRT_ProcessState_kDisconnected = 2,
+  PJRT_ProcessState_kConnected = 3,
+  PJRT_ProcessState_kError = 4,
+} PJRT_ProcessState;
+
+// TODO: mwhittaker - Add the remaining fields from
+// tensorflow::CoordinatedTaskStateInfo.
+struct PJRT_ProcessInfo {
+  int task_id;
+  uint64_t incarnation_id;
+  PJRT_ProcessState state;
+  int error_code;
+  const char* error_message;
+  size_t error_message_size;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_ProcessInfo, error_message_size);
+
+struct PJRT_Client_UpdateGlobalProcessInfo_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  PJRT_ProcessInfo* process_infos;
+  size_t num_process_infos;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_UpdateGlobalProcessInfo_Args,
+                          num_process_infos);
+
+// Updates the PjRt client with information about all global processes.
+//
+// Recall that a distributed program may consist of multiple PjRt clients
+// spanning multiple machines. These clients perform collective operations, like
+// AllGather, to execute a distributed program. UpdateGlobalProcessInfo updates
+// a PjRt client with information about all processes.
+typedef PJRT_Error* PJRT_Client_UpdateGlobalProcessInfo(
+    PJRT_Client_UpdateGlobalProcessInfo_Args* args);
 
 struct PJRT_Client_AddressableMemories_Args {
   size_t struct_size;
@@ -1712,9 +1770,12 @@ struct PJRT_Executable_GetCompiledMemoryStats_Args {
   int64_t host_output_size_in_bytes;          // out
   int64_t host_alias_size_in_bytes;           // out
   int64_t host_temp_size_in_bytes;            // out
+
+  // Device memory stats, from xla::CompiledMemoryStats.
+  int64_t peak_memory_in_bytes;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_GetCompiledMemoryStats_Args,
-                          host_temp_size_in_bytes);
+                          peak_memory_in_bytes);
 
 // Return memory stats that allow callers to estimate memory usage when running
 // this executable. The memory stats could contain usage info from different
@@ -1803,9 +1864,14 @@ struct PJRT_Executable_DeserializeAndLoad_Args {
   const char* serialized_executable;
   size_t serialized_executable_size;
   PJRT_LoadedExecutable* loaded_executable;  // out
+  // Serialized CompileOptionsProto or null (to use the options
+  // from the serialized executable).
+  // (https://github.com/openxla/xla/blob/main/xla/pjrt/compile_options.proto)
+  const char* overridden_serialized_compile_options;
+  size_t overridden_serialized_compile_options_size;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_DeserializeAndLoad_Args,
-                          loaded_executable);
+                          overridden_serialized_compile_options_size);
 
 // Deserializes an executable serialized by `PJRT_Executable_Serialize`.
 // `serialized_executable` must have been produced by the same platform and
@@ -2359,6 +2425,7 @@ typedef PJRT_Error* PJRT_Compile(PJRT_Compile_Args* args);
 
 // -------------------------------- API access ---------------------------------
 
+
 // This is needed to be able to compile on CRAN
 #define _PJRT_API_STRUCT_FIELD(fn_type) fn_type* fn_type##_
 
@@ -2374,7 +2441,7 @@ typedef struct PJRT_Api {
   _PJRT_API_STRUCT_FIELD(PJRT_Error_GetCode);
 
   _PJRT_API_STRUCT_FIELD(PJRT_Plugin_Initialize);
-  _PJRT_API_STRUCT_FIELD(plugin_attributes);
+  _PJRT_API_STRUCT_FIELD(PJRT_Plugin_Attributes);
 
   _PJRT_API_STRUCT_FIELD(PJRT_Event_Destroy);
   _PJRT_API_STRUCT_FIELD(PJRT_Event_IsReady);
@@ -2505,11 +2572,12 @@ typedef struct PJRT_Api {
   _PJRT_API_STRUCT_FIELD(PJRT_Client_DmaUnmap);
 
   _PJRT_API_STRUCT_FIELD(PJRT_Client_CreateUninitializedBuffer);
+  _PJRT_API_STRUCT_FIELD(PJRT_Client_UpdateGlobalProcessInfo);
 } PJRT_Api;
 
 enum {
   PJRT_Api_STRUCT_SIZE =
-      PJRT_STRUCT_SIZE(PJRT_Api, PJRT_Client_CreateUninitializedBuffer_)
+      PJRT_STRUCT_SIZE(PJRT_Api, PJRT_Client_UpdateGlobalProcessInfo_)
 };
 
 #undef _PJRT_API_STRUCT_FIELD

--- a/inst/include/xla/pjrt/c/pjrt_c_api_ffi_extension.h
+++ b/inst/include/xla/pjrt/c/pjrt_c_api_ffi_extension.h
@@ -1,0 +1,104 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_PJRT_C_PJRT_C_API_FFI_EXTENSION_H_
+#define XLA_PJRT_C_PJRT_C_API_FFI_EXTENSION_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "xla/pjrt/c/pjrt_c_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// PJRT FFI extension provides capabilities for integrating with a
+// backend-specific FFI (foreign function interface) library, i.e. for XLA CPU
+// and GPU backends it gives access to the XLA FFI internals.
+//
+// See: https://en.wikipedia.org/wiki/Foreign_function_interface
+#define PJRT_API_FFI_EXTENSION_VERSION 2
+
+struct PJRT_FFI_TypeID_Register_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+
+  const char* type_name;
+  size_t type_name_size;
+  int64_t type_id;  // in-out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_FFI_TypeID_Register_Args, type_id);
+
+// Registers external type in a static type registry. If `type_id` is set to `0`
+// XLA will assign a unique type id to it and return via out argument, otherwise
+// it will verify that user-provided type id matches previously registered type
+// id for the given type name.
+typedef PJRT_Error* PJRT_FFI_TypeID_Register(
+    PJRT_FFI_TypeID_Register_Args* args);
+
+// User-data that will be forwarded to the FFI handlers. Deleter is optional,
+// and can be nullptr. Deleter will be called when the context is destroyed.
+typedef struct PJRT_FFI_UserData {
+  int64_t type_id;
+  void* data;
+  void (*deleter)(void* data);
+} PJRT_FFI_UserData;
+
+struct PJRT_FFI_UserData_Add_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+
+  PJRT_ExecuteContext* context;
+  PJRT_FFI_UserData user_data;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_FFI_UserData_Add_Args, user_data);
+
+// Adds a user data to the execute context.
+typedef PJRT_Error* PJRT_FFI_UserData_Add(PJRT_FFI_UserData_Add_Args* args);
+
+typedef enum PJRT_FFI_Handler_TraitsBits {
+  PJRT_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE = 1u << 0,
+} PJRT_FFI_Handler_TraitsBits;
+
+struct PJRT_FFI_Register_Handler_Args {
+  size_t struct_size;
+  const char* target_name;
+  size_t target_name_size;
+  void* handler;  // XLA_FFI_Handler* for typed FFI calls
+  const char* platform_name;
+  size_t platform_name_size;
+  PJRT_FFI_Handler_TraitsBits traits;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_FFI_Register_Handler_Args, traits);
+
+// Registers an FFI call handler for a specific platform.
+// Only supports typed FFI handlers (XLA_FFI_Handler*).
+typedef PJRT_Error* PJRT_FFI_Register_Handler(
+    PJRT_FFI_Register_Handler_Args* args);
+
+typedef struct PJRT_FFI_Extension {
+  PJRT_Extension_Base base;
+  PJRT_FFI_TypeID_Register* type_id_register;
+  PJRT_FFI_UserData_Add* user_data_add;
+  PJRT_FFI_Register_Handler* register_handler;
+} PJRT_FFI;
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_FFI_Extension, register_handler);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // XLA_PJRT_C_PJRT_C_API_FFI_EXTENSION_H_

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -35,10 +35,10 @@ std::unique_ptr<PJRTClient> PJRTPlugin::client_create() {
 }
 
 std::vector<std::pair<std::string, SEXP>> PJRTPlugin::attributes() const {
-  plugin_attributes_Args args{};
-  args.struct_size = sizeof(plugin_attributes_Args);
+  PJRT_Plugin_Attributes_Args args{};
+  args.struct_size = sizeof(PJRT_Plugin_Attributes_Args);
   args.extension_start = nullptr;
-  check_err(api.get(), api->plugin_attributes_(&args));
+  check_err(api.get(), api->PJRT_Plugin_Attributes_(&args));
   std::vector<std::pair<std::string, SEXP>> out;
   for (size_t i = 0; i < args.num_attributes; ++i) {
     const PJRT_NamedValue &nv = args.attributes[i];

--- a/tools/copy-header.R
+++ b/tools/copy-header.R
@@ -10,14 +10,17 @@ if (!dir.exists("inst/include")) {
   dir.create("inst/include", recursive = TRUE)
 }
 
-HEADER_FILES <- "xla/pjrt/c/pjrt_c_api.h"
+HEADER_FILES <- c(
+  "xla/pjrt/c/pjrt_c_api.h",
+  "xla/pjrt/c/pjrt_c_api_ffi_extension.h"
+)
 
 for (file in HEADER_FILES) {
   from <- fs::path(XLA_SRC, file)
   dest <- fs::path("inst/include", file)
 
   if (!fs::dir_exists(fs::path_dir(dest))) {
-    fs::dir_create(fs::path_dir(dest))
+    fs::dir_create(fs::path_dir(dest), recurse = TRUE)
   }
 
   fs::file_copy(from, dest, overwrite = TRUE)


### PR DESCRIPTION
In preparation for #49, we'll need an updated version of the PJRT headers + the pjrt_ffi_extension headers copied.