### PR TITLE
feat(exec): add argument `simplify` that prevents unpacking lists of length 1

### DIFF
--- a/R/loaded_executable.R
+++ b/R/loaded_executable.R
@@ -35,15 +35,11 @@ pjrt_execute <- function(executable, ..., execution_options = NULL, simplify = T
 
   result <- impl_loaded_executable_execute(executable, input, execution_options)
 
-  if (is.list(result)) {
-    return(result)
+  if (simplify && length(result) == 1L) {
+    return(result[[1]])
   }
 
-  if (simplify) {
-    return(result)
-  }
-
-  list(result)
+  result
 }
 
 check_loaded_executable <- function(x) {

--- a/R/loaded_executable.R
+++ b/R/loaded_executable.R
@@ -12,9 +12,12 @@
 #'   Named are ignored and arguments are passed in order.
 #' @param execution_options (`PJRTExecuteOptions`)\cr
 #'   Optional execution options for configuring buffer donation and other settings.
+#' @param simplify (`logical(1)`)\cr
+#'   If `TRUE` (default), a single output is returned as a `PJRTBuffer`.
+#'   If `FALSE`, a single output is returned as a `list` of length 1 containing a `PJRTBuffer`.
 #' @return `PJRTBuffer` | `list` of `PJRTBuffer`s
 #' @export
-pjrt_execute <- function(executable, ..., execution_options = NULL) {
+pjrt_execute <- function(executable, ..., execution_options = NULL, simplify = TRUE) {
   if (!is.null(...names())) {
     stop("Expected unnamed arguments")
   }
@@ -28,7 +31,19 @@ pjrt_execute <- function(executable, ..., execution_options = NULL) {
     check_execution_options(execution_options)
   }
 
-  impl_loaded_executable_execute(executable, input, execution_options)
+  assert_flag(simplify)
+
+  result <- impl_loaded_executable_execute(executable, input, execution_options)
+
+  if (is.list(result)) {
+    return(result)
+  }
+
+  if (simplify) {
+    return(result)
+  }
+
+  list(result)
 }
 
 check_loaded_executable <- function(x) {

--- a/man/pjrt_execute.Rd
+++ b/man/pjrt_execute.Rd
@@ -4,7 +4,7 @@
 \alias{pjrt_execute}
 \title{Execute a PJRT program}
 \usage{
-pjrt_execute(executable, ..., execution_options = NULL)
+pjrt_execute(executable, ..., execution_options = NULL, simplify = TRUE)
 }
 \arguments{
 \item{executable}{(\code{PJRTLoadedExecutable})\cr
@@ -16,6 +16,10 @@ Named are ignored and arguments are passed in order.}
 
 \item{execution_options}{(\code{PJRTExecuteOptions})\cr
 Optional execution options for configuring buffer donation and other settings.}
+
+\item{simplify}{(\code{logical(1)})\cr
+If \code{TRUE} (default), a single output is returned as a \code{PJRTBuffer}.
+If \code{FALSE}, a single output is returned as a \code{list} of length 1 containing a \code{PJRTBuffer}.}
 }
 \value{
 \code{PJRTBuffer} | \code{list} of \code{PJRTBuffer}s

--- a/src/pjrt.cpp
+++ b/src/pjrt.cpp
@@ -452,19 +452,13 @@ SEXP impl_loaded_executable_execute(
 
   auto outs = executable->execute(inputs, *execution_options);
 
-  if (outs.size() == 1) {
-    Rcpp::XPtr<rpjrt::PJRTBuffer> xptr(outs[0].release(), true);
+  Rcpp::List result(outs.size());
+  for (size_t i = 0; i < outs.size(); ++i) {
+    Rcpp::XPtr<rpjrt::PJRTBuffer> xptr(outs[i].release(), true);
     xptr.attr("class") = "PJRTBuffer";
-    return xptr;
-  } else {
-    Rcpp::List result(outs.size());
-    for (size_t i = 0; i < outs.size(); ++i) {
-      Rcpp::XPtr<rpjrt::PJRTBuffer> xptr(outs[i].release(), true);
-      xptr.attr("class") = "PJRTBuffer";
-      result[i] = xptr;
-    }
-    return result;
+    result[i] = xptr;
   }
+  return result;
 }
 
 // [[Rcpp::export()]]

--- a/tests/testthat/test-loaded_executable.R
+++ b/tests/testthat/test-loaded_executable.R
@@ -27,3 +27,16 @@ test_that("can return two values", {
   expect_equal(as_array(result[[1]]), 3)
   expect_equal(as_array(result[[2]]), 7)
 })
+
+test_that("single-output returns list when simplify=FALSE", {
+  path <- system.file("programs/jax-stablehlo-no-arg.mlir", package = "pjrt")
+  program <- pjrt_program(path = path, format = "mlir")
+  executable <- pjrt_compile(program)
+  result <- pjrt_execute(executable, simplify = FALSE)
+  expect_list(result, types = "PJRTBuffer", len = 1L)
+  expect_equal(as_array(result[[1]]), 3)
+
+  result <- pjrt_execute(executable, simplify = TRUE)
+  expect_class(result, "PJRTBuffer")
+  expect_equal(as_array(result), 3)
+})


### PR DESCRIPTION
The auto unpacking is nice for direct use, but in `anvil`, consistency is better.