### PR TITLE
fix(pjrt_program): don't check whether src is a file

### DIFF
--- a/R/program.R
+++ b/R/program.R
@@ -20,11 +20,6 @@ pjrt_program <- function(src = NULL, path = NULL, format = c("mlir", "hlo")) {
   )
   temp_file <- NULL
   if (!is.null(src)) {
-    if (checkmate::test_file_exists(src)) {
-      stop(
-        "You passed a file path to src, which expects a string containing the source code."
-      )
-    }
     temp_file <- tempfile()
     writeLines(src, temp_file)
     path <- temp_file

--- a/tests/testthat/test-program.R
+++ b/tests/testthat/test-program.R
@@ -14,10 +14,3 @@ test_that("can load MLIR program", {
 
   expect_snapshot(print(program))
 })
-
-test_that("error message", {
-  on.exit(unlink(path))
-  path <- tempfile(fileext = ".mlir")
-  writeLines("foo", path)
-  expect_error(pjrt_program(path), "You passed a file path to src")
-})


### PR DESCRIPTION
Otherwise there is a warning for very long file names.