### PR TITLE
Add Linux ARM (aarch64) support

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,6 +22,7 @@ jobs:
           - { os: "ubuntu", r: "release", platform: "cpu" }
           - { os: "ubuntu", r: "release", platform: "cpu", depends_only: true}
           - { os: "ubuntu", r: "release", platform: "cuda"}
+          - { os: "ubuntu-arm", r: "release", platform: "cpu"}
           - { os: "windows", r: "release", platform: "cpu"}
           - { os: "macos", platform: "metal"}
 
@@ -34,6 +35,8 @@ jobs:
             as-cran: 'false'
           - config: {os: "ubuntu", platform: "cpu"}
             runner: 'ubuntu-latest'
+          - config: {os: "ubuntu-arm", platform: "cpu"}
+            runner: 'ubuntu-24.04-arm'
           - config: {os: "macos", platform: "cpu"}
             runner: 'macos-latest'
             setup: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,11 +24,11 @@ jobs:
           - { os: "ubuntu", r: "release", platform: "cuda"}
           - { os: "ubuntu-arm", r: "release", platform: "cpu"}
           - { os: "windows", r: "release", platform: "cpu"}
-          - { os: "macos", platform: "metal"}
+          - { os: "macos", r: "release", platform: "metal"}
 
         include:
           - config: {os: "ubuntu", platform: "cuda"}
-            container: {image: 'nvidia/cuda:12.8.1-runtime-ubuntu24.04', options: '--gpus all --runtime=nvidia'}
+            container: {image: 'nvidia/cuda:12.8.1-base-ubuntu24.04', options: '--gpus all --runtime=nvidia'}
             runner: ['self-hosted', 'gpu']
             extra-packages: "any::rcmdcheck, cuda12.8"
             extra-repositories: "https://r-xla.r-universe.dev, https://mlverse.r-universe.dev"
@@ -45,7 +45,7 @@ jobs:
           - config: {os: "windows"}
             runner: 'windows-latest'
           - config: {os: "macos", platform: "metal"}
-            runner: ['self-hosted', 'metal']
+            runner: 'macos-15'
             setup: |
               brew install protobuf@21
               brew link protobuf@21 --force --overwrite

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pjrt
 Title: R Interface to PJRT
-Version: 0.1.1.9000
+Version: 0.1.1.9001
 Authors@R: c(
     person("Sebastian", "Fischer", , "seb.fischer@tutamail.com", role = c("cre", "aut"),
            comment = c(ORCID = "https://orcid.org/0000-0002-9609-3197")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pjrt (development version)
 
+## Platform Support
+
+* Added support for Linux ARM (aarch64) using CPU backend.
+
 ## Asynchronous API
 
 Operations such as host <-> device transfers and program execution were previously only

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -255,6 +255,12 @@ plugin_url <- function(platform) {
     return(url)
   }
 
+  if (os == "linux" && arch == "aarch64") {
+    # on linux arm download from our pre-built artifacts
+    url <- "https://github.com/r-xla/pjrt-builds/releases/download/pjrt/pjrt-6319f0d-linux-aarch64.tar.gz"
+    return(url)
+  }
+
   sprintf(
     "https://github.com/zml/pjrt-artifacts/releases/download/v%s/pjrt-%s_%s-%s.tar.gz",
     zml_version,
@@ -290,6 +296,8 @@ plugin_arch <- function() {
     return("amd64")
   } else if (Sys.info()["machine"] == "arm64") {
     return("arm64")
+  } else if (Sys.info()["machine"] == "aarch64") {
+    return("aarch64")
   } else if (.Platform$r_arch == "x64") {
     return("amd64")
   } else if (.Platform$r_arch == "arm64") {

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -257,7 +257,7 @@ plugin_url <- function(platform) {
 
   if (os == "linux" && arch == "aarch64") {
     # on linux arm download from our pre-built artifacts
-    url <- "https://github.com/r-xla/pjrt-builds/releases/download/pjrt/pjrt-6319f0d-linux-aarch64.tar.gz"
+    url <- "https://github.com/r-xla/pjrt-builds/releases/download/pjrt/pjrt-a4df377-linux-aarch64.tar.gz"
     return(url)
   }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -114,9 +114,12 @@ pjrt_execute(executable, x, y)
 
 ## Platform Support
 
-* **Linux**
+* **Linux (x86_64)**
   * :white_check_mark: CPU backend is fully supported.
   * :white_check_mark: CUDA (NVIDIA GPU) backend is fully supported.
+* **Linux (ARM)**
+  * :white_check_mark: CPU backend is fully supported.
+  * :x: GPU is not supported.
 * **Windows**
   * :white_check_mark: CPU backend is fully supported.
   * :warning: GPU is only supported via Windows Subsystem for Linux (WSL2).

--- a/README.md
+++ b/README.md
@@ -139,9 +139,12 @@ pjrt_execute(executable, x, y)
 
 ## Platform Support
 
-- **Linux**
+- **Linux (x86_64)**
   - :white_check_mark: CPU backend is fully supported.
   - :white_check_mark: CUDA (NVIDIA GPU) backend is fully supported.
+- **Linux (ARM)**
+  - :white_check_mark: CPU backend is fully supported.
+  - :x: GPU is not supported.
 - **Windows**
   - :white_check_mark: CPU backend is fully supported.
   - :warning: GPU is only supported via Windows Subsystem for Linux

--- a/tests/testthat/test-aaa.R
+++ b/tests/testthat/test-aaa.R
@@ -3,3 +3,9 @@ test_that("cuda plugin can be downloaded", {
   expect_no_error(pjrt_plugin("cuda"))
   expect_true(plugin_is_downloaded("cuda"))
 })
+
+test_that("metal plugin can be downloaded", {
+  skip_if(!is_metal(), "Not running on Metal platform")
+  expect_no_error(pjrt_plugin("metal"))
+  expect_true(plugin_is_downloaded("metal"))
+})


### PR DESCRIPTION
## Summary
- Add `aarch64` architecture detection in `plugin_arch()` (Linux ARM reports `"aarch64"`, not `"arm64"` like macOS)
- Route Linux ARM plugin downloads to `r-xla/pjrt-builds` artifacts (CPU only, no GPU support)
- Add `ubuntu-arm` entry to R-CMD-check CI matrix (runs on `ubuntu-24.04-arm`)
- Update README platform support table to distinguish Linux x86_64 (CPU + CUDA) from Linux ARM (CPU only, no GPU)

## Verification
On a Linux ARM machine:
```r
library(pjrt)
pjrt_buffer(1, device = "cpu")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)