### PR TITLE
Accept DataType objects in dtype parameter

### DIFF
--- a/R/buffer.R
+++ b/R/buffer.R
@@ -88,7 +88,9 @@ pjrt_buffer <- function(data, dtype = NULL, device = NULL, shape = NULL, ...) {
 
 buffer_identity <- function(data, dtype = NULL, device = NULL, shape = NULL, ...) {
   buf <- data
-  if (inherits(dtype, "DataType")) dtype <- as.character(dtype)
+  if (inherits(dtype, "DataType")) {
+    dtype <- as.character(dtype)
+  }
   if (!is.null(dtype) && !identical(dtype, as.character(elt_type(buf)))) {
     cli_abort("Must use the same data type as the data")
   }

--- a/R/buffer.R
+++ b/R/buffer.R
@@ -41,7 +41,7 @@ is_buffer <- function(x) {
 #'
 #' @param data (any)\cr
 #'  Data to convert to a `PJRTBuffer`.
-#' @param dtype (`NULL` | `character(1)`)\cr
+#' @param dtype (`NULL` | `character(1)` | [`DataType`][tengen::DataType])\cr
 #'   The type of the buffer.
 #'   Currently supported types are:
 #'   - `"pred"`: predicate (i.e. a boolean)
@@ -88,6 +88,7 @@ pjrt_buffer <- function(data, dtype = NULL, device = NULL, shape = NULL, ...) {
 
 buffer_identity <- function(data, dtype = NULL, device = NULL, shape = NULL, ...) {
   buf <- data
+  if (inherits(dtype, "DataType")) dtype <- as.character(dtype)
   if (!is.null(dtype) && !identical(dtype, as.character(elt_type(buf)))) {
     cli_abort("Must use the same data type as the data")
   }
@@ -134,9 +135,7 @@ pjrt_empty <- function(dtype, shape, device = NULL) {
   if (!any(shape == 0)) {
     cli_abort("Empty buffers must have at least one dimension equal to 0")
   }
-  if (dtype %in% c("i1", "bool")) {
-    dtype <- "pred"
-  }
+  dtype <- as_dtype_string(dtype)
   device <- as_pjrt_device(device)
   data <- if (identical(dtype, "pred")) {
     logical()
@@ -178,11 +177,18 @@ recycle_data <- function(data, shape) {
   }
 }
 
-convert_buffer_args <- function(data, dtype, device, shape, default, recycle = TRUE, ...) {
-  dtype <- dtype %??% default
+as_dtype_string <- function(dtype) {
+  if (inherits(dtype, "DataType")) {
+    dtype <- as.character(dtype)
+  }
   if (dtype %in% c("i1", "bool")) {
     dtype <- "pred"
   }
+  dtype
+}
+
+convert_buffer_args <- function(data, dtype, device, shape, default, recycle = TRUE, ...) {
+  dtype <- as_dtype_string(dtype %??% default)
   shape <- shape %??% get_dims(data)
   device <- as_pjrt_device(device)
   client <- client_from_device(device)
@@ -255,6 +261,7 @@ pjrt_buffer.raw <- function(
   if (is.null(dtype)) {
     cli_abort("dtype must be provided")
   }
+  dtype <- as_dtype_string(dtype)
   if (...length()) {
     cli_abort("Unused arguments")
   }
@@ -327,6 +334,7 @@ pjrt_scalar.raw <- function(
   if (is.null(dtype)) {
     cli_abort("dtype must be provided")
   }
+  dtype <- as_dtype_string(dtype)
   check_raw_buffer_size(data, dtype, integer())
   args <- convert_buffer_args(data, dtype, device, integer(), "f32", recycle = FALSE, ...)
   buffer <- do.call(impl_client_buffer_from_raw, args)

--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -636,6 +636,65 @@ test_that("i1 is alias for pred", {
   expect_equal(pjrt_empty(shape = c(1, 0), "i1"), pjrt_empty(shape = c(1, 0), "pred"))
 })
 
+test_that("pjrt_buffer accepts DataType objects", {
+  # pjrt_buffer with DataType
+  expect_equal(
+    pjrt_buffer(c(1, 2, 3), dtype = tengen::FloatType(32)),
+    pjrt_buffer(c(1, 2, 3), dtype = "f32")
+  )
+  expect_equal(
+    pjrt_buffer(c(1, 2, 3), dtype = tengen::FloatType(64)),
+    pjrt_buffer(c(1, 2, 3), dtype = "f64")
+  )
+  expect_equal(
+    pjrt_buffer(1L, dtype = tengen::IntegerType(32)),
+    pjrt_buffer(1L, dtype = "i32")
+  )
+  expect_equal(
+    pjrt_buffer(1L, dtype = tengen::UIntegerType(8)),
+    pjrt_buffer(1L, dtype = "ui8")
+  )
+  expect_equal(
+    pjrt_buffer(TRUE, dtype = tengen::BooleanType()),
+    pjrt_buffer(TRUE, dtype = "pred")
+  )
+
+  # pjrt_scalar with DataType
+  expect_equal(
+    pjrt_scalar(42L, dtype = tengen::IntegerType(32)),
+    pjrt_scalar(42L, dtype = "i32")
+  )
+  expect_equal(
+    pjrt_scalar(3.14, dtype = tengen::FloatType(64)),
+    pjrt_scalar(3.14, dtype = "f64")
+  )
+
+  # pjrt_empty with DataType
+  expect_equal(
+    pjrt_empty(dtype = tengen::FloatType(32), shape = c(0, 3)),
+    pjrt_empty(dtype = "f32", shape = c(0, 3))
+  )
+
+  # raw buffer with DataType
+  raw_data <- as.raw(rep(0, 24))
+  expect_equal(
+    pjrt_buffer(raw_data, dtype = tengen::FloatType(32), shape = c(2, 3), row_major = FALSE),
+    pjrt_buffer(raw_data, dtype = "f32", shape = c(2, 3), row_major = FALSE)
+  )
+
+  # raw scalar with DataType
+  raw_scalar <- as.raw(rep(0, 4))
+  expect_equal(
+    pjrt_scalar(raw_scalar, dtype = tengen::FloatType(32)),
+    pjrt_scalar(raw_scalar, dtype = "f32")
+  )
+
+  # identity preserves buffer when DataType matches
+  buf <- pjrt_buffer(c(1, 2), dtype = "f32")
+  expect_equal(pjrt_buffer(buf, dtype = tengen::FloatType(32)), buf)
+  expect_error(pjrt_buffer(buf, dtype = tengen::IntegerType(32)), "Must use the same data type")
+})
+
 test_that("raw buffer validates dtype and shape compatibility", {
   # f32 is 4 bytes per element, shape c(2, 3) = 6 elements = 24 bytes
   expect_error(


### PR DESCRIPTION
## Summary
- `pjrt_buffer()`, `pjrt_scalar()`, and `pjrt_empty()` now accept tengen `DataType` objects (e.g. `FloatType(32)`, `IntegerType(32)`) in addition to character strings for the `dtype` parameter.
- Adds internal `as_dtype_string()` helper that normalizes `DataType` → character and handles `"i1"`/`"bool"` → `"pred"` aliasing in one place.

## Test plan
- [x] All existing tests pass (449 total, 0 failures)
- [x] New test covers all entry points: `pjrt_buffer()` (numeric, logical, integer, unsigned, raw), `pjrt_scalar()` (numeric, integer, raw), `pjrt_empty()`, and buffer identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)