### PR TITLE
release: pjrt 0.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pjrt
 Title: R Interface to PJRT
-Version: 0.1.1.9001
+Version: 0.2.0
 Authors@R: c(
     person("Sebastian", "Fischer", , "seb.fischer@tutamail.com", role = c("cre", "aut"),
            comment = c(ORCID = "https://orcid.org/0000-0002-9609-3197")),
@@ -21,13 +21,11 @@ Imports:
     rlang,
     safetensors(>= 0.2.0),
     withr,
-    tengen (>= 0.1.0)
+    tengen (>= 0.2.0)
 Suggests:
     testthat (>= 3.0.0)
 LinkingTo:
     Rcpp
-Remotes:
-    r-xla/tengen
 Additional_repositories: https://r-xla.r-universe.dev
 Config/build/compilation-database: true
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,4 @@
-# pjrt (development version)
-
-## Platform Support
-
-* Added support for Linux ARM (aarch64) using CPU backend.
+# pjrt 0.2.0
 
 ## Asynchronous API
 
@@ -25,11 +21,19 @@ Specifically:
 ## Features
 
 * Added `dtype` support for `PJRTBuffer`s via the `tengen::dtype` S3 generic. `"bool"` is now accepted as an alias for `"i1"`/`"pred"`.
+* Accept `DataType` objects in the `dtype` parameter of `pjrt_buffer()`.
 * Support `device` argument in `pjrt_compile()`.
 
 ## Bug fixes
 
 * Protect from segfaults in raw to buffer conversion.
+* Protect from segfault during device mismatch in `pjrt_execute()`.
+
+## Platforms & Installation
+
+* Added support for Linux ARM (aarch64) using CPU backend.
+* Simplified CUDA installation via the `cuda12.8` package, which now only
+  requires compatible drivers to be installed.
 
 ## Miscellaneous
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ Specifically:
 * `pjrt_buffer()` and `pjrt_execute()` return immediately, but the returned buffer is not
   necessarily ready. To await a transfer or computation of a buffer, use
   `await()`. However, this is handled within PJRT, so this function never has to
-  be called from a user.
+  be called by a user.
 * `as_array()` is still synchronous, but there is now the asynchronous version
   `as_array_async()` but this is rarely needed.
   If used, it returns a `PJRTArrayPromise` object which can be converted to


### PR DESCRIPTION
## Summary

Release pjrt 0.2.0.

## Changelog

### Asynchronous API

Operations such as host <-> device transfers and program execution were previously only synchronous. Now, they are asynchronous which has considerable performance benefits, especially on GPU.

* `pjrt_buffer()` and `pjrt_execute()` return immediately, but the returned buffer is not necessarily ready.
* `as_array_async()` provides non-blocking device-to-host transfer.
* `is_ready()` polls without blocking.

### Features

* Added `dtype` support for `PJRTBuffer`s via the `tengen::dtype` S3 generic. `"bool"` is now accepted as an alias for `"i1"`/`"pred"`.
* Accept `DataType` objects in the `dtype` parameter of `pjrt_buffer()`.
* Support `device` argument in `pjrt_compile()`.

### Bug fixes

* Protect from segfaults in raw to buffer conversion.
* Protect from segfault during device mismatch in `pjrt_execute()`.

### Platforms & Installation

* Added support for Linux ARM (aarch64) using CPU backend.
* Simplified CUDA installation via the `cuda12.8` package, which now only requires compatible drivers to be installed.

### Miscellaneous

* The printer for `PJRTBuffer` now uses `"bool"` instead of `"pred"` to avoid discrepancies with {anvil}.

## Test plan

- [ ] CI passes on all platforms (CPU, CUDA, Metal)