### PR TITLE
feat: cache PJRTDevice instances for stable identity

### DIFF
--- a/R/buffer.R
+++ b/R/buffer.R
@@ -434,7 +434,7 @@ print.PJRTElementType <- function(x, ...) {
 
 #' @export
 device.PJRTBuffer <- function(x, ...) {
-  impl_buffer_device(x)
+  cached_device(impl_buffer_device(x))
 }
 
 

--- a/R/client.R
+++ b/R/client.R
@@ -127,7 +127,12 @@ platform.PJRTClient <- function(x, ...) {
 #' devices(client)
 #' @export
 devices <- function(client = NULL) {
-  impl_client_devices(as_pjrt_client(client))
+  client <- as_pjrt_client(client)
+  plat <- platform(client)
+  if (!exists(plat, envir = the[["devices"]], inherits = FALSE)) {
+    the[["devices"]][[plat]] <- impl_client_devices(client)
+  }
+  the[["devices"]][[plat]]
 }
 
 #' @title Convert to PJRT Device
@@ -187,6 +192,23 @@ client_from_device <- function(device) {
     cli_abort("Must be a PJRTDevice")
   }
   the[["clients"]][[platform(device)]]
+}
+
+# Map a freshly-created PJRTDevice xptr to the cached device with the same
+# string representation, so equal devices share one external pointer and can
+# be used as stable hashtab keys.
+cached_device <- function(device) {
+  client <- client_from_device(device)
+  if (is.null(client)) {
+    return(device)
+  }
+  target <- as.character(device)
+  for (d in devices(client)) {
+    if (identical(as.character(d), target)) {
+      return(d)
+    }
+  }
+  device
 }
 
 #' @export

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -2,6 +2,7 @@ the <- new.env(parent = emptyenv())
 
 the[["plugins"]] <- new.env(parent = emptyenv())
 the[["clients"]] <- new.env(parent = emptyenv())
+the[["devices"]] <- new.env(parent = emptyenv())
 the[["custom_calls"]] <- list()
 the[["config"]] <- list(
   cpu_device_count = 1L,

--- a/tests/testthat/test-device.R
+++ b/tests/testthat/test-device.R
@@ -52,3 +52,22 @@ test_that("platform", {
   skip_if(!(is_metal() || is_cuda()))
   device_name <- Sys.getenv("PJRT_PLATFORM")
 })
+
+test_that("devices are cached (stable external pointer)", {
+  expect_identical(pjrt_device("cpu"), pjrt_device("cpu"))
+  expect_identical(pjrt_device("cpu:0"), pjrt_device("cpu:0"))
+  expect_identical(pjrt_device("cpu:0"), devices("cpu")[[1L]])
+})
+
+test_that("device() on a buffer returns the cached device", {
+  buf <- pjrt_buffer(1, device = "cpu:0")
+  expect_identical(device(buf), pjrt_device("cpu:0"))
+})
+
+test_that("PJRTDevice is usable as a hashtab key", {
+  ht <- utils::hashtab()
+  utils::sethash(ht, pjrt_device("cpu:0"), "value0")
+  utils::sethash(ht, pjrt_device("cpu:1"), "value1")
+  expect_equal(utils::gethash(ht, pjrt_device("cpu:0")), "value0")
+  expect_equal(utils::gethash(ht, pjrt_device("cpu:1")), "value1")
+})

--- a/tests/testthat/test-device.R
+++ b/tests/testthat/test-device.R
@@ -66,8 +66,9 @@ test_that("device() on a buffer returns the cached device", {
 
 test_that("PJRTDevice is usable as a hashtab key", {
   ht <- utils::hashtab()
-  utils::sethash(ht, pjrt_device("cpu:0"), "value0")
-  utils::sethash(ht, pjrt_device("cpu:1"), "value1")
-  expect_equal(utils::gethash(ht, pjrt_device("cpu:0")), "value0")
-  expect_equal(utils::gethash(ht, pjrt_device("cpu:1")), "value1")
+  dev1 <- pjrt_device("cpu:0")
+  dev2 <- pjrt_device("cpu:0")
+  ht[[dev1]] <- "a"
+  ht[[dev2]] <- "b"
+  expect_equal(ht[[dev1]], "b")
 })


### PR DESCRIPTION
## Summary

Ensures equal `PJRTDevice` objects share a single external pointer so devices can be used as stable `hashtab` keys (e.g. for device-keyed caches in downstream packages).

- `devices(client)` now caches the per-client device list in the global `the[['devices']]` env, so repeated calls return the same list of xptrs.
- A new internal `cached_device()` helper maps a freshly-created `PJRTDevice` xptr to the cached device with the same string representation (by looking it up via its client). It is used from `device.PJRTBuffer()` so that `device(buf)` returns the canonical cached device rather than a fresh xptr.
- `pjrt_device("cpu:0")` already routes through `devices()`, so cached identity is automatic there.

## Verification

```r
devtools::load_all()

# Same xptr from repeated lookups
identical(pjrt_device("cpu:0"), pjrt_device("cpu:0"))  # TRUE
identical(pjrt_device("cpu:0"), devices("cpu")[[1L]])  # TRUE

# device() on a buffer returns the cached device
buf <- pjrt_buffer(1, device = "cpu:0")
identical(device(buf), pjrt_device("cpu:0"))  # TRUE

# Usable as a hashtab key
ht <- utils::hashtab()
utils::sethash(ht, pjrt_device("cpu:0"), "value0")
utils::gethash(ht, pjrt_device("cpu:0"))  # "value0"
```

New tests covering these cases live in `tests/testthat/test-device.R`.