### PR TITLE
fix: use local hardware id for device_ordinal

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -30,9 +30,12 @@ std::vector<PJRT_Device *> PJRTClient::devices() {
 std::unique_ptr<PJRTLoadedExecutable> PJRTClient::compile(
     const PJRTProgram &program, PJRTCompileOptions &compile_options,
     PJRTDevice &device) {
-  // Set device_assignment so the executable targets the requested device.
-  // device_ordinal alone is insufficient: it uses StreamExecutor ordinals,
-  // which don't distinguish virtual CPU devices.
+  // device_ordinal is a local hardware (StreamExecutor) ordinal, while the
+  // device_assignment uses global PJRT device IDs. These coincide on a single
+  // host but diverge under distributed PJRT clients, so fetch both. Setting
+  // only device_ordinal is insufficient: the CPU plugin exposes multiple
+  // virtual devices sharing one StreamExecutor ordinal, so device_assignment
+  // is needed to disambiguate them.
   PJRT_Device_GetDescription_Args desc_args{};
   desc_args.struct_size = sizeof(PJRT_Device_GetDescription_Args);
   desc_args.device = device.device;
@@ -44,9 +47,14 @@ std::unique_ptr<PJRTLoadedExecutable> PJRTClient::compile(
   id_args.device_description = desc_args.device_description;
   check_err(this->api.get(), this->api->PJRT_DeviceDescription_Id_(&id_args));
 
+  PJRT_Device_LocalHardwareId_Args hw_args{};
+  hw_args.struct_size = sizeof(PJRT_Device_LocalHardwareId_Args);
+  hw_args.device = device.device;
+  check_err(this->api.get(), this->api->PJRT_Device_LocalHardwareId_(&hw_args));
+
   auto *build_opts =
       compile_options.compile_options.mutable_executable_build_options();
-  build_opts->set_device_ordinal(id_args.id);
+  build_opts->set_device_ordinal(hw_args.local_hardware_id);
 
   auto *da = build_opts->mutable_device_assignment();
   da->set_replica_count(build_opts->num_replicas());

--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -874,7 +874,7 @@ describe("copy_buffer", {
     buf <- pjrt_buffer(matrix(c(1, 2, 3, 4), nrow = 2), dtype = "f32", device = "cpu:0")
     buf2 <- copy_buffer(buf, "cuda:0")
 
-    expect_equal(platform(device(buf2)), "cuda")
+    expect_equal(device(buf2), pjrt_device("cuda:0"))
     expect_equal(as_array(buf2), as_array(buf))
     expect_equal(shape(buf2), shape(buf))
     expect_equal(dtype(buf2), dtype(buf))


### PR DESCRIPTION
## Summary

Follow-up to #181. That PR fixed CPU virtual-device targeting by adding a `device_assignment`, but it also switched `device_ordinal` to the PJRT global device id. These two IDs are not the same concept and should not be conflated.

## The two IDs

The PJRT C API exposes two distinct identifiers for a device:

- **`PJRT_Device_LocalHardwareId`** — the local StreamExecutor ordinal, i.e. the physical device index on the current host (e.g. the CUDA device index `0..N-1` on a host with N GPUs). This is what XLA's `executable_build_options.device_ordinal` expects: it is passed down to the backend to select a physical device.
- **`PJRT_DeviceDescription_Id`** — the global PJRT device id, unique across all hosts participating in a distributed PJRT client. This is what `DeviceAssignmentProto.replica_device_ids` expects: the assignment is expressed in terms of logical PJRT devices, not host-local ordinals.

On a single-host client the two happen to coincide (host 0 has devices 0..N-1 with matching local and global ids), so the previous commit works in practice on typical workstations. But on a distributed client the global id of, say, host 1's second GPU might be `5`, while its `local_hardware_id` is `1`. Using `5` as `device_ordinal` would either fail lookup or target the wrong physical device.

The CPU plugin is the motivating edge case: it exposes multiple virtual devices that share one StreamExecutor ordinal, so `device_ordinal` alone cannot disambiguate them — `device_assignment` does. The global id is correct there.

## Fix

Fetch both IDs and route each to its correct field:

- `device_ordinal` ← `PJRT_Device_LocalHardwareId` (local hardware ordinal)
- `device_assignment.replica_device_ids[0]` ← `PJRT_DeviceDescription_Id` (global id)

Behavior on single-host clients (the only currently supported configuration) is unchanged; the existing `cpu devices work` test still passes.

## Test plan

- [x] `testthat::test_file("tests/testthat/test-loaded_executable.R")` — 33 pass, 1 CRAN skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)