### PR TITLE
release: pjrt 0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pjrt
 Title: R Interface to PJRT
-Version: 0.2.0.9000
+Version: 0.3.0
 Authors@R: c(
     person("Sebastian", "Fischer", , "seb.fischer@tutamail.com", role = c("cre", "aut"),
            comment = c(ORCID = "https://orcid.org/0000-0002-9609-3197")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
   protobuf versions are installed.
 * Compiling a program for a specific CPU device (e.g. `cpu:1`) now targets
   that device instead of silently falling back to `cpu:0`.
+* Fixed device targeting when compiling against a distributed PJRT client,
+  where global device IDs and local hardware ordinals diverge.
 
 ## Error messages
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# pjrt (development version)
+# pjrt 0.3.0
 
 ## Features
 
@@ -6,6 +6,9 @@
 * New `pjrt_register_custom_call()` allows external packages to register C/C++
   XLA FFI handlers with the PJRT plugin. Registration is deferred until the
   plugin loads, so handlers can be registered during `.onLoad()`.
+* `pjrt_device()` now returns cached `PJRTDevice` instances, so repeated calls
+  for the same device yield objects with stable identity (useful for hashing
+  and caching, e.g. in `{anvil}`'s JIT).
 
 ## Bug fixes
 
@@ -14,6 +17,8 @@
   protobuf versions are installed.
 * Compiling a program for a specific CPU device (e.g. `cpu:1`) now targets
   that device instead of silently falling back to `cpu:0`.
+* `PJRTDevice$device_ordinal` now reports the local hardware ordinal instead of
+  the global device id.
 
 ## Error messages
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,8 +17,6 @@
   protobuf versions are installed.
 * Compiling a program for a specific CPU device (e.g. `cpu:1`) now targets
   that device instead of silently falling back to `cpu:0`.
-* `PJRTDevice$device_ordinal` now reports the local hardware ordinal instead of
-  the global device id.
 
 ## Error messages
 


### PR DESCRIPTION
## Summary

Release of pjrt 0.3.0.

### Features

- Added `buffer_copy()` to copy buffers between devices.
- New `pjrt_register_custom_call()` lets external packages register C/C++ XLA FFI handlers (deferred until plugin load, so handlers can be registered during `.onLoad()`).
- `pjrt_device()` now returns cached `PJRTDevice` instances for stable identity (useful for hashing and JIT caching in `{anvil}`).

### Bug fixes

- `configure` now uses the `protoc` matching the linked protobuf library, preventing version mismatches.
- Compiling for a specific CPU device (e.g. `cpu:1`) now targets that device instead of falling back to `cpu:0`.
- Fixed device targeting when compiling against a distributed PJRT client, where global device IDs and local hardware ordinals diverge.

### Error messages

- Improved error when using CUDA on unsupported OS/architecture.

## Verification

- CI passes on release branch