### PR TITLE
feat: extend scan_na to cover all four NA-trap integer dtypes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,11 @@
 * `pjrt_buffer()`, `pjrt_scalar()`, and `as_array()` gain a `scan_na`
   argument (default `FALSE`). When `TRUE`, host → device transfers error if
   the input contains any `NA` values; device → host transfers error if a
-  materialized `i32` buffer surfaces an `NA_integer_` (the `-2147483648`
-  bit-pattern collision). Opt-in safety check for callers that want to fail
-  loudly on missing-value loss.
+  materialized `i32`, `ui32`, `i64`, or `ui64` buffer surfaces a value that
+  R cannot distinguish from `NA` (`INT_MIN` for the 32-bit dtypes,
+  `INT64_MIN` for the 64-bit dtypes — the latter via `bit64::integer64`).
+  Opt-in safety check for callers that want to fail loudly on
+  silent NA collisions.
 
 # pjrt 0.3.0
 

--- a/R/buffer.R
+++ b/R/buffer.R
@@ -441,20 +441,27 @@ elt_type <- function(x) {
 #' @param x ([`PJRTBuffer`][pjrt_buffer])\cr
 #'   Buffer to convert.
 #' @param scan_na (`logical(1)`)\cr
-#'   If `TRUE` and the buffer dtype is `"i32"`, scan the materialized R
-#'   integer vector for `NA_integer_` values and raise an error if any are
-#'   present. No-op for non-`i32` dtypes.
+#'   If `TRUE` and the buffer dtype is one of the four integer dtypes that
+#'   round-trip through a signed R container (`i32` / `ui32` via `integer`,
+#'   `i64` / `ui64` via `bit64::integer64`), scan the materialized vector
+#'   for the reserved NA bit pattern (`INT_MIN` or `INT64_MIN`) and raise an
+#'   error if any are present. No-op for float, boolean, and small-integer
+#'   dtypes (which have no NA-collision risk).
 #' @param ... Additional arguments (unused).
 #' @return An R `array` (or `vector` for shape `integer()`).
 #' @export
 as_array.PJRTBuffer <- function(x, scan_na = FALSE, ...) {
   result <- value(as_array_async(x))
   assert_flag(scan_na)
-  if (scan_na && identical(as.character(elt_type(x)), "i32") && anyNA(result)) {
-    cli_abort(c(
-      "Materialized {.cls i32} buffer contains the bit pattern {.val -2147483648}, which R interprets as {.val NA_integer_}.",
-      i = "This collision is irrecoverable: the device value and {.val NA} are indistinguishable in R. Set {.code scan_na = FALSE} to skip this check."
-    ))
+  if (scan_na) {
+    dt <- as.character(elt_type(x))
+    if (dt %in% c("i32", "ui32", "i64", "ui64") && anyNA(result)) {
+      cli_abort(c(
+        "Materialized {.cls {dt}} buffer contains a value that R cannot distinguish from {.val NA}.",
+        i = "{.val i32}/{.val ui32} reserve the bit pattern {.val -2147483648} ({.code INT_MIN}); {.val i64}/{.val ui64} reserve {.val -9223372036854775808} ({.code INT64_MIN}).",
+        i = "This collision is irrecoverable: the device value and {.val NA} are indistinguishable in R. Set {.code scan_na = FALSE} to skip this check."
+      ))
+    }
   }
   result
 }

--- a/man/as_array.PJRTBuffer.Rd
+++ b/man/as_array.PJRTBuffer.Rd
@@ -11,9 +11,12 @@
 Buffer to convert.}
 
 \item{scan_na}{(\code{logical(1)})\cr
-If \code{TRUE} and the buffer dtype is \code{"i32"}, scan the materialized R
-integer vector for \code{NA_integer_} values and raise an error if any are
-present. No-op for non-\code{i32} dtypes.}
+If \code{TRUE} and the buffer dtype is one of the four integer dtypes that
+round-trip through a signed R container (\code{i32} / \code{ui32} via \code{integer},
+\code{i64} / \code{ui64} via \code{bit64::integer64}), scan the materialized vector
+for the reserved NA bit pattern (\code{INT_MIN} or \code{INT64_MIN}) and raise an
+error if any are present. No-op for float, boolean, and small-integer
+dtypes (which have no NA-collision risk).}
 
 \item{...}{Additional arguments (unused).}
 }

--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -240,31 +240,46 @@ test_that("pjrt_buffer scan_na = TRUE errors on NA input", {
   expect_no_error(pjrt_buffer(c(TRUE, FALSE), scan_na = TRUE))
 })
 
-test_that("as_array scan_na = TRUE errors on NA_integer_ collision for i32", {
-  # NA_integer_ is the bit pattern -2147483648; i32 round-trip surfaces it as NA.
-  buf <- pjrt_buffer(NA_integer_, dtype = "i32")
-  expect_true(anyNA(as_array(buf)))
-  expect_error(
-    as_array(buf, scan_na = TRUE),
-    "indistinguishable"
-  )
+test_that("as_array scan_na = TRUE errors on NA collision for i32 / ui32 / i64 / ui64", {
+  # i32: NA_integer_ bit pattern is INT_MIN (-2147483648).
+  buf_i32 <- pjrt_buffer(NA_integer_, dtype = "i32")
+  expect_true(anyNA(as_array(buf_i32)))
+  expect_error(as_array(buf_i32, scan_na = TRUE), "indistinguishable")
 
-  # No collision -> no error.
-  buf_clean <- pjrt_buffer(1:3, dtype = "i32")
-  expect_no_error(as_array(buf_clean, scan_na = TRUE))
+  # ui32: planting 2^31 (= 0x80000000) wraps to INT_MIN as signed int32.
+  bytes_u32 <- as.raw(c(0x00, 0x00, 0x00, 0x80))
+  client <- pjrt_client("cpu")
+  buf_u32 <- impl_client_buffer_from_raw(client, devices(client)[[1L]], bytes_u32, 1L, "ui32")
+  expect_true(anyNA(as_array(buf_u32)))
+  expect_error(as_array(buf_u32, scan_na = TRUE), "indistinguishable")
+
+  # i64: planting INT64_MIN.
+  bytes_i64 <- as.raw(c(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80))
+  buf_i64 <- impl_client_buffer_from_raw(client, devices(client)[[1L]], bytes_i64, 1L, "i64")
+  expect_true(anyNA(as_array(buf_i64)))
+  expect_error(as_array(buf_i64, scan_na = TRUE), "indistinguishable")
+
+  # ui64: planting 2^63 wraps to INT64_MIN.
+  buf_u64 <- impl_client_buffer_from_raw(client, devices(client)[[1L]], bytes_i64, 1L, "ui64")
+  expect_true(anyNA(as_array(buf_u64)))
+  expect_error(as_array(buf_u64, scan_na = TRUE), "indistinguishable")
+
+  # Clean buffers — no collision, no error.
+  expect_no_error(as_array(pjrt_buffer(1:3, dtype = "i32"), scan_na = TRUE))
+  expect_no_error(as_array(pjrt_buffer(1L, dtype = "i64"), scan_na = TRUE))
 })
 
-test_that("as_array scan_na is a no-op for non-i32 dtypes", {
-  # Float NaN is not flagged because i32 is the only dtype with the
-  # NA-sentinel collision in R.
+test_that("as_array scan_na is a no-op for float / bool / small-integer dtypes", {
+  # Float NaN is not flagged — it isnt the R-NA bit pattern in the same way.
   buf_f32 <- pjrt_buffer(c(1, NaN, 3), dtype = "f32")
   expect_no_error(as_array(buf_f32, scan_na = TRUE))
 
-  buf_i64 <- pjrt_buffer(1L, dtype = "i64")
-  expect_no_error(as_array(buf_i64, scan_na = TRUE))
-
   buf_pred <- pjrt_buffer(c(TRUE, FALSE), dtype = "pred")
   expect_no_error(as_array(buf_pred, scan_na = TRUE))
+
+  # i8/i16/ui8/ui16 fit fully inside R's int32 with headroom — no collision.
+  buf_i8 <- pjrt_buffer(c(-128L, 0L, 127L), dtype = "i8")
+  expect_no_error(as_array(buf_i8, scan_na = TRUE))
 })
 
 test_that("pjrt_buffer preserves 3d dimensions", {


### PR DESCRIPTION
`scan_na = TRUE` in `as_array.PJRTBuffer` previously only checked `i32` for the `-2147483648`/`NA_integer_` collision. The same collision exists for `ui32` (`2^31` wraps to `INT_MIN`), `i64` (`-2^63 = INT64_MIN` is `bit64`'s `NA_integer64_`), and `ui64` (`2^63` wraps to `INT64_MIN`). Checking only `i32` left three identical silent-corruption channels open.

The check now fires for any of the four integer dtypes when `anyNA()` on the materialized vector is true (`bit64::anyNA.integer64` correctly recognizes `INT64_MIN` as NA, so the same condition covers both 32- and 64-bit cases). The error message distinguishes the two bit patterns.

Tests in test-buffer.R extended: planted-byte coverage for each of the four collisions, plus a "no-op for float/bool/small-integer" case. Default remains `FALSE` — anvl is the caller that chooses the safer default.