### PR TITLE
linalg: handle wide-matrix CUDA SVD via transposed attribute

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -141,10 +141,6 @@ impl_device_to_string <- function(device) {
     .Call(`_pjrt_impl_device_to_string`, device)
 }
 
-impl_device_platform <- function(device) {
-    .Call(`_pjrt_impl_device_platform`, device)
-}
-
 impl_buffer_print <- function(buffer, max_rows, max_width, max_rows_slice) {
     invisible(.Call(`_pjrt_impl_buffer_print`, buffer, max_rows, max_width, max_rows_slice))
 }

--- a/R/buffer.R
+++ b/R/buffer.R
@@ -597,9 +597,7 @@ device.PJRTBuffer <- function(x, ...) {
 #' @include client.R
 #' @export
 platform.PJRTBuffer <- function(x, ...) {
-  desc <- as.character(device(x))
-  letters_only <- regmatches(desc, regexpr("^[A-Za-z]+", desc, perl = TRUE))
-  tolower(sub("Device$", "", letters_only))
+  platform_from_device_string(as.character(device(x)))
 }
 
 

--- a/R/device.R
+++ b/R/device.R
@@ -27,5 +27,14 @@ pjrt_device <- function(device) {
 #' @include client.R
 #' @export
 platform.PJRTDevice <- function(x, ...) {
-  impl_device_platform(x)
+  platform_from_device_string(as.character(x))
+}
+
+# Extract the platform name (e.g. "cuda", "cpu") from a PJRT device's
+# `to_string` representation (e.g. "CudaDevice(id=0)", "CpuDevice(id=0)"):
+# strip the leading [A-Za-z]+ run, drop a trailing "Device", and lowercase.
+# Used for both PJRTDevice and PJRTBuffer so they agree with platform.PJRTClient.
+platform_from_device_string <- function(desc) {
+  letters_only <- regmatches(desc, regexpr("^[A-Za-z]+", desc, perl = TRUE))
+  tolower(sub("Device$", "", letters_only))
 }

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -44,9 +44,6 @@ plugin_client_create <- function(plugin, platform, options = list()) {
   })
   client <- impl_plugin_client_create(plugin, opts)
   the[["clients"]][[platform]] <- client
-  # in order to go from device -> client, we go through the platform name, which might
-  # not be the same as the "cuda" string, but might be "nvidia h100" etc.
-  the[["clients"]][[platform(devices(client)[[1L]])]] <- client
   client
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -414,17 +414,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// impl_device_platform
-std::string impl_device_platform(Rcpp::XPtr<rpjrt::PJRTDevice> device);
-RcppExport SEXP _pjrt_impl_device_platform(SEXP deviceSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::XPtr<rpjrt::PJRTDevice> >::type device(deviceSEXP);
-    rcpp_result_gen = Rcpp::wrap(impl_device_platform(device));
-    return rcpp_result_gen;
-END_RCPP
-}
 // impl_buffer_print
 void impl_buffer_print(Rcpp::XPtr<rpjrt::PJRTBuffer> buffer, int max_rows, int max_width, int max_rows_slice);
 RcppExport SEXP _pjrt_impl_buffer_print(SEXP bufferSEXP, SEXP max_rowsSEXP, SEXP max_widthSEXP, SEXP max_rows_sliceSEXP) {
@@ -683,7 +672,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_pjrt_impl_plugin_pjrt_api_version", (DL_FUNC) &_pjrt_impl_plugin_pjrt_api_version, 1},
     {"_pjrt_impl_plugin_attributes", (DL_FUNC) &_pjrt_impl_plugin_attributes, 1},
     {"_pjrt_impl_device_to_string", (DL_FUNC) &_pjrt_impl_device_to_string, 1},
-    {"_pjrt_impl_device_platform", (DL_FUNC) &_pjrt_impl_device_platform, 1},
     {"_pjrt_impl_buffer_print", (DL_FUNC) &_pjrt_impl_buffer_print, 4},
     {"_pjrt_impl_buffer_is_ready", (DL_FUNC) &_pjrt_impl_buffer_is_ready, 1},
     {"_pjrt_impl_buffer_await", (DL_FUNC) &_pjrt_impl_buffer_await, 1},

--- a/src/pjrt.cpp
+++ b/src/pjrt.cpp
@@ -608,25 +608,6 @@ std::string impl_device_to_string(Rcpp::XPtr<rpjrt::PJRTDevice> device) {
 }
 
 // [[Rcpp::export()]]
-std::string impl_device_platform(Rcpp::XPtr<rpjrt::PJRTDevice> device) {
-  auto api = device->api;
-  PJRT_Device_GetDescription_Args desc_args{};
-  desc_args.struct_size = sizeof(PJRT_Device_GetDescription_Args);
-  desc_args.device = device->device;
-  check_err(api.get(), api->PJRT_Device_GetDescription_(&desc_args));
-
-  PJRT_DeviceDescription_Kind_Args kind_args{};
-  kind_args.struct_size = sizeof(PJRT_DeviceDescription_Kind_Args);
-  kind_args.device_description = desc_args.device_description;
-  check_err(api.get(), api->PJRT_DeviceDescription_Kind_(&kind_args));
-
-  std::string kind(kind_args.device_kind, kind_args.device_kind_size);
-  // Convert to lowercase for consistency
-  std::transform(kind.begin(), kind.end(), kind.begin(), ::tolower);
-  return kind;
-}
-
-// [[Rcpp::export()]]
 void impl_buffer_print(Rcpp::XPtr<rpjrt::PJRTBuffer> buffer, int max_rows,
                        int max_width, int max_rows_slice) {
   buffer_print(buffer, max_rows, max_width, max_rows_slice);

--- a/src/svd_cuda.cpp
+++ b/src/svd_cuda.cpp
@@ -1,13 +1,10 @@
 // CUDA SVD via cuSOLVER gesvd.
 //
-// cuSOLVER's gesvd requires m >= n. For wide inputs (m < n) the lowering
-// in anvl sets a `transposed = true` attribute and declares operand / U / Vt
-// as row-major instead of column-major. The col-major (m, n) buffer is
-// bit-identical to a row-major (n, m) view of A^T, so by swapping m and n
-// here and pointing gesvd's U / Vt output buffers at the original Vt / U
-// slots, cuSOLVER's outputs land in the right places under the same
-// reinterpretation — no explicit transpose required. This mirrors JAX's
-// `_svd_gpu_sub_lowering` strategy.
+// gesvd requires m >= n. For m < n we use A = U D V^t  <=>  A^t = V D^t U^t:
+// the lowering transposes A (by declaring operand / U / Vt as row-major,
+// which reinterprets the buffer as A^t), we run gesvd on A^t, then transpose
+// back implicitly via the same layout trick on the outputs — which on this
+// side just means swapping the U / Vt output slots.
 //
 // jobu / jobvt are passed as 'S' (reduced); for m >= n that gives:
 //   U  : (m, n)    -- ldu = m
@@ -42,12 +39,6 @@ static Error svd_cuda_impl(void *stream, ScratchAllocator &scratch,
   int m_orig, n_orig;
   PJRT_RETURN_IF_ERROR(dim_to_int(dims[0], "rows", m_orig));
   PJRT_RETURN_IF_ERROR(dim_to_int(dims[1], "cols", n_orig));
-  // When the lowering set transposed = true, the operand / U / Vt buffers
-  // have row-major layout, which is bit-identical to col-major with rows
-  // and cols swapped. cuSOLVER reads col-major, so we swap m / n here and
-  // it sees A^T (shape n_orig x m_orig). A^T = V S U^T, so cuSOLVER's U
-  // output corresponds to original Vt and vice versa — we point its U
-  // output buffer at vt_data and its Vt output buffer at u_data.
   int m = transposed ? n_orig : m_orig;
   int n = transposed ? m_orig : n_orig;
 

--- a/src/svd_cuda.cpp
+++ b/src/svd_cuda.cpp
@@ -1,9 +1,13 @@
 // CUDA SVD via cuSOLVER gesvd.
 //
-// cuSOLVER's gesvd requires m >= n. For the m < n case the user can call
-// nv_svd on the transpose and swap U <-> V; we surface a clear
-// InvalidArgument error rather than silently doing this. JAX's older
-// cuSOLVER path has the same restriction.
+// cuSOLVER's gesvd requires m >= n. For wide inputs (m < n) the lowering
+// in anvl sets a `transposed = true` attribute and declares operand / U / Vt
+// as row-major instead of column-major. The col-major (m, n) buffer is
+// bit-identical to a row-major (n, m) view of A^T, so by swapping m and n
+// here and pointing gesvd's U / Vt output buffers at the original Vt / U
+// slots, cuSOLVER's outputs land in the right places under the same
+// reinterpretation — no explicit transpose required. This mirrors JAX's
+// `_svd_gpu_sub_lowering` strategy.
 //
 // jobu / jobvt are passed as 'S' (reduced); for m >= n that gives:
 //   U  : (m, n)    -- ldu = m
@@ -27,29 +31,33 @@ namespace rpjrt {
 #ifndef _WIN32
 template <typename T>
 static Error svd_cuda_impl(void *stream, ScratchAllocator &scratch,
-                           AnyBuffer input, Result<AnyBuffer> u_out,
-                           Result<AnyBuffer> s_out, Result<AnyBuffer> vt_out) {
+                           bool transposed, AnyBuffer input,
+                           Result<AnyBuffer> u_out, Result<AnyBuffer> s_out,
+                           Result<AnyBuffer> vt_out) {
   Solver solver(get_cuda_libs());
   PJRT_RETURN_IF_ERROR(solver.begin(scratch, stream));
   auto &g = solver.g;
 
   auto dims = input.dimensions();
-  int m, n;
-  PJRT_RETURN_IF_ERROR(dim_to_int(dims[0], "rows", m));
-  PJRT_RETURN_IF_ERROR(dim_to_int(dims[1], "cols", n));
-  if (m < n) {
-    return Error::InvalidArgument(
-        "CUDA SVD requires m >= n; transpose the input and swap U<->V "
-        "for the wide case");
-  }
+  int m_orig, n_orig;
+  PJRT_RETURN_IF_ERROR(dim_to_int(dims[0], "rows", m_orig));
+  PJRT_RETURN_IF_ERROR(dim_to_int(dims[1], "cols", n_orig));
+  // When the lowering set transposed = true, the operand / U / Vt buffers
+  // have row-major layout, which is bit-identical to col-major with rows
+  // and cols swapped. cuSOLVER reads col-major, so we swap m / n here and
+  // it sees A^T (shape n_orig x m_orig). A^T = V S U^T, so cuSOLVER's U
+  // output corresponds to original Vt and vice versa — we point its U
+  // output buffer at vt_data and its Vt output buffer at u_data.
+  int m = transposed ? n_orig : m_orig;
+  int n = transposed ? m_orig : n_orig;
 
-  // input_ptr stays as CUdeviceptr because it feeds memcpy_dtod below; the
-  // U/S/Vt outputs are only handed to cuSOLVER, which wants typed pointers,
-  // so we skip the CUdeviceptr round-trip for them.
   auto input_ptr = reinterpret_cast<CUdeviceptr>(input.untyped_data());
   T *u_data = static_cast<T *>((*u_out).untyped_data());
   T *s_data = static_cast<T *>((*s_out).untyped_data());
   T *vt_data = static_cast<T *>((*vt_out).untyped_data());
+
+  T *u_param = transposed ? vt_data : u_data;
+  T *vt_param = transposed ? u_data : vt_data;
 
   // Cast m to size_t before multiplying: dim_to_int only guarantees each
   // dimension individually fits in int, not their product. e.g. a
@@ -79,7 +87,7 @@ static Error svd_cuda_impl(void *stream, ScratchAllocator &scratch,
   // converted to signed char at the call site, no truncation.
   PJRT_RETURN_IF_GPU_ERROR(
       CuSolver<T>::gesvd(g)(solver.handle.get(), 'S', 'S', m, n, d_a, m, s_data,
-                            u_data, m, vt_data, n, d_work, lwork,
+                            u_param, m, vt_param, n, d_work, lwork,
                             /*rwork=*/nullptr, solver.info),
       "cusolverDn?gesvd");
 
@@ -88,14 +96,15 @@ static Error svd_cuda_impl(void *stream, ScratchAllocator &scratch,
 #endif  // _WIN32
 
 static Error do_svd_cuda(void *stream, ScratchAllocator scratch,
-                         AnyBuffer input, Result<AnyBuffer> u_out,
-                         Result<AnyBuffer> s_out, Result<AnyBuffer> vt_out) {
+                         bool transposed, AnyBuffer input,
+                         Result<AnyBuffer> u_out, Result<AnyBuffer> s_out,
+                         Result<AnyBuffer> vt_out) {
 #ifdef _WIN32
   return Error(ErrorCode::kUnimplemented,
                "CUDA SVD is not supported on Windows");
 #else
   PJRT_DISPATCH_FLOAT(input.element_type(), svd_cuda_impl, stream, scratch,
-                      input, u_out, s_out, vt_out);
+                      transposed, input, u_out, s_out, vt_out);
 #endif
 }
 
@@ -103,6 +112,7 @@ XLA_FFI_DEFINE_HANDLER(svd_handler_cuda, do_svd_cuda,
                        Ffi::Bind()
                            .Ctx<PlatformStream<void *>>()
                            .Ctx<ScratchAllocator>()
+                           .Attr<bool>("transposed")
                            .Arg<AnyBuffer>()
                            .Ret<AnyBuffer>()
                            .Ret<AnyBuffer>()

--- a/tests/testthat/helper-linalg.R
+++ b/tests/testthat/helper-linalg.R
@@ -7,11 +7,31 @@ tensor_type <- function(spec) {
   sprintf("tensor<%sx%s>", paste(spec$dims, collapse = "x"), spec$dtype)
 }
 
-build_program <- function(target, in_specs, out_specs) {
+row_major_layout <- function(ndim) {
+  dims <- paste(rev(seq_len(ndim) - 1L), collapse = ", ")
+  sprintf("dense<[%s]> : tensor<%dxindex>", dims, ndim)
+}
+
+# `attrs`: optional named list of extra `key = "<mlir>"` entries inserted into
+# the custom_call attribute dictionary (e.g. `list(backend_config = "{...}")`).
+# `in_layouts` / `out_layouts`: optional character vectors of MLIR layout
+# expressions, parallel to `in_specs` / `out_specs`. NULL means column-major.
+build_program <- function(
+  target,
+  in_specs,
+  out_specs,
+  attrs = list(),
+  in_layouts = NULL,
+  out_layouts = NULL
+) {
   in_types <- vapply(in_specs, tensor_type, character(1))
   out_types <- vapply(out_specs, tensor_type, character(1))
-  in_layouts <- vapply(in_specs, function(s) col_major_layout(length(s$dims)), character(1))
-  out_layouts <- vapply(out_specs, function(s) col_major_layout(length(s$dims)), character(1))
+  if (is.null(in_layouts)) {
+    in_layouts <- vapply(in_specs, function(s) col_major_layout(length(s$dims)), character(1))
+  }
+  if (is.null(out_layouts)) {
+    out_layouts <- vapply(out_specs, function(s) col_major_layout(length(s$dims)), character(1))
+  }
   arg_names <- paste0("%a", seq_along(in_specs))
   ret_names <- paste0("%out", seq_along(out_specs))
 
@@ -34,13 +54,29 @@ build_program <- function(target, in_specs, out_specs) {
     collapse = ", "
   )
 
+  extra_attr_lines <- if (length(attrs) > 0L) {
+    paste0(
+      ",\n    ",
+      paste(
+        vapply(
+          names(attrs),
+          function(k) sprintf("%s = %s", k, attrs[[k]]),
+          character(1)
+        ),
+        collapse = ",\n    "
+      )
+    )
+  } else {
+    ""
+  }
+
   sprintf(
     'func.func @main(%s) -> (%s) {
   %s = stablehlo.custom_call @%s(%s) {
     call_target_name = "%s",
     api_version = 4 : i32,
     operand_layouts = [%s],
-    result_layouts = [%s]
+    result_layouts = [%s]%s
   } : (%s) -> (%s)
   func.return %s : %s
 }',
@@ -52,6 +88,7 @@ build_program <- function(target, in_specs, out_specs) {
     target,
     paste(in_layouts, collapse = ", "),
     paste(out_layouts, collapse = ", "),
+    extra_attr_lines,
     paste(in_types, collapse = ", "),
     paste(out_types, collapse = ", "),
     paste(ret_names, collapse = ", "),
@@ -66,9 +103,24 @@ build_program <- function(target, in_specs, out_specs) {
 # If an in_spec carries an `aliases` field, that input is donated into the
 # named output (via the `tf.aliasing_output` attribute emitted by
 # build_program).
-run_linalg <- function(target, inputs, in_specs, out_specs) {
+run_linalg <- function(
+  target,
+  inputs,
+  in_specs,
+  out_specs,
+  attrs = list(),
+  in_layouts = NULL,
+  out_layouts = NULL
+) {
   stopifnot(length(inputs) == length(in_specs))
-  src <- build_program(target, in_specs, out_specs)
+  src <- build_program(
+    target,
+    in_specs,
+    out_specs,
+    attrs = attrs,
+    in_layouts = in_layouts,
+    out_layouts = out_layouts
+  )
   program <- pjrt_compile(pjrt_program(src))
   bufs <- Map(
     function(x, s) pjrt_buffer(x, dtype = s$dtype),
@@ -89,8 +141,23 @@ run_linalg <- function(target, inputs, in_specs, out_specs) {
 # (e.g. cuSOLVER getrf / syevd write A in place) that R-level array
 # semantics would mask, since `pjrt_buffer(a, ...)` doesn't tie `a` and the
 # device buffer together.
-expect_inputs_preserved <- function(target, inputs, in_specs, out_specs) {
-  src <- build_program(target, in_specs = in_specs, out_specs = out_specs)
+expect_inputs_preserved <- function(
+  target,
+  inputs,
+  in_specs,
+  out_specs,
+  attrs = list(),
+  in_layouts = NULL,
+  out_layouts = NULL
+) {
+  src <- build_program(
+    target,
+    in_specs = in_specs,
+    out_specs = out_specs,
+    attrs = attrs,
+    in_layouts = in_layouts,
+    out_layouts = out_layouts
+  )
   exec <- pjrt_compile(pjrt_program(src))
   bufs <- Map(
     function(x, s) pjrt_buffer(x, dtype = s$dtype),

--- a/tests/testthat/test-linalg.R
+++ b/tests/testthat/test-linalg.R
@@ -232,12 +232,9 @@ describe("lu", {
 describe("svd", {
   # Exercises the `svd` (gesdd / cusolverDnXgesvd) custom call: thin SVD on
   # tall and wide matrices in f32 / f64, plus input donation. cuSOLVER's
-  # `gesvd` requires m >= n; the CUDA handler reads a `transposed` attribute
-  # and, when set, swaps m / n and the U / Vt output buffers so the same
-  # bytes serve a row-major (m, n) view of A as a col-major (n, m) view of
-  # A^T (mirroring JAX's `_svd_gpu_sub_lowering`). Anvl's lowering sets
-  # `transposed = TRUE` on CUDA when m < n; these tests exercise both
-  # branches of the FFI directly.
+  # `gesvd` requires m >= n, so for m < n the CUDA handler reads a
+  # `transposed` attribute and runs gesvd on A^t via a layout trick; these
+  # tests exercise both branches of the FFI directly.
   #
   # Correctness: thin SVD returns U (m x k), S (k), Vt (k x n) with U and V
   # having orthonormal columns and S non-negative. The factorisation is not
@@ -257,10 +254,8 @@ describe("svd", {
     U %*% Sd %*% Vt
   }
 
-  # CUDA-only `transposed` attribute: when m < n, the lowering passes
-  # transposed = true and switches operand / U / Vt to row-major layouts.
-  # The CPU handler is shape-agnostic and doesn't read the attribute, so
-  # tests on CPU don't pass anything.
+  # CUDA-only: when m < n, pass transposed = true and switch operand / U / Vt
+  # to row-major layouts. The CPU handler ignores both.
   svd_attrs <- function(m, n) {
     if (!is_cuda()) {
       return(list())

--- a/tests/testthat/test-linalg.R
+++ b/tests/testthat/test-linalg.R
@@ -231,8 +231,13 @@ describe("lu", {
 
 describe("svd", {
   # Exercises the `svd` (gesdd / cusolverDnXgesvd) custom call: thin SVD on
-  # tall and wide matrices in f32 / f64, input donation, and the CUDA
-  # m >= n shape constraint enforced by cuSOLVER.
+  # tall and wide matrices in f32 / f64, plus input donation. cuSOLVER's
+  # `gesvd` requires m >= n; the CUDA handler reads a `transposed` attribute
+  # and, when set, swaps m / n and the U / Vt output buffers so the same
+  # bytes serve a row-major (m, n) view of A as a col-major (n, m) view of
+  # A^T (mirroring JAX's `_svd_gpu_sub_lowering`). Anvl's lowering sets
+  # `transposed = TRUE` on CUDA when m < n; these tests exercise both
+  # branches of the FFI directly.
   #
   # Correctness: thin SVD returns U (m x k), S (k), Vt (k x n) with U and V
   # having orthonormal columns and S non-negative. The factorisation is not
@@ -252,6 +257,28 @@ describe("svd", {
     U %*% Sd %*% Vt
   }
 
+  # CUDA-only `transposed` attribute: when m < n, the lowering passes
+  # transposed = true and switches operand / U / Vt to row-major layouts.
+  # The CPU handler is shape-agnostic and doesn't read the attribute, so
+  # tests on CPU don't pass anything.
+  svd_attrs <- function(m, n) {
+    if (!is_cuda()) {
+      return(list())
+    }
+    transposed <- if (m < n) "true" else "false"
+    list(backend_config = sprintf("{transposed = %s}", transposed))
+  }
+
+  svd_layouts <- function(m, n) {
+    if (!is_cuda() || m >= n) {
+      return(list(in_layouts = NULL, out_layouts = NULL))
+    }
+    list(
+      in_layouts = row_major_layout(2L),
+      out_layouts = c(row_major_layout(2L), col_major_layout(1L), row_major_layout(2L))
+    )
+  }
+
   run_svd <- function(a, dtype, donate = FALSE) {
     m <- nrow(a)
     n <- ncol(a)
@@ -263,6 +290,7 @@ describe("svd", {
     if (donate) {
       in_spec$aliases <- 1L
     }
+    layouts <- svd_layouts(m, n)
     run_linalg(
       "svd",
       inputs = list(a),
@@ -271,7 +299,10 @@ describe("svd", {
         list(dims = c(m, k), dtype = dtype),
         list(dims = k, dtype = dtype),
         list(dims = c(k, n), dtype = dtype)
-      )
+      ),
+      attrs = svd_attrs(m, n),
+      in_layouts = layouts$in_layouts,
+      out_layouts = layouts$out_layouts
     )
   }
 
@@ -309,17 +340,10 @@ describe("svd", {
   })
 
   it("factorises a wide matrix (m < n) in f64 and f32", {
-    # CUDA's cusolverDnXgesvd requires m >= n; tested separately below.
-    skip_if(is_cuda())
     withr::local_seed(22)
     a <- matrix(rnorm(20), 4, 5)
     expect_matches_r_svd(a, "f64")
     expect_matches_r_svd(a, "f32")
-  })
-
-  it("rejects m < n on CUDA", {
-    skip_if(!is_cuda())
-    expect_error(run_svd(matrix(rnorm(6), 2, 3), "f64"), "m >= n")
   })
 
   it("works with a donated input buffer", {
@@ -343,7 +367,8 @@ describe("svd", {
         list(dims = c(5, 4), dtype = "f64"),
         list(dims = 4, dtype = "f64"),
         list(dims = c(4, 4), dtype = "f64")
-      )
+      ),
+      attrs = svd_attrs(5, 4)
     )
   })
 })


### PR DESCRIPTION
cuSOLVER's gesvd requires m >= n. The anvl lowering now sets a `transposed = true` attribute and declares operand / U / Vt as row-major for m < n inputs. The CUDA SVD handler swaps m / n and points U / Vt output buffers at the opposite slots so cuSOLVER's outputs land correctly under the row-major reinterpretation.

Updates build_program / run_linalg helpers to accept extra custom_call attrs and explicit layouts.