### PR TITLE
fix: free PJRT_Error in check_err instead of leaking it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pjrt
 Title: R Interface to PJRT
-Version: 0.4.0
+Version: 0.4.0.9000
 Authors@R: c(
     person("Sebastian", "Fischer", , "seb.fischer@tutamail.com", role = c("cre", "aut"),
            comment = c(ORCID = "https://orcid.org/0000-0002-9609-3197")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# pjrt (development version)
+
+## Bug fixes
+
+* `check_err()` no longer leaks the underlying `PJRT_Error` when
+  converting a plugin error into an R exception.
+
 # pjrt 0.4.0
 
 ## Features

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,16 +2,29 @@
 
 #include <optional>
 #include <stdexcept>
+#include <string>
 
 #include "xla/pjrt/c/pjrt_c_api.h"
 
+void destroy_error(const PJRT_Api *api, PJRT_Error *err) {
+  if (err == nullptr) return;
+  PJRT_Error_Destroy_Args args{};
+  args.struct_size = sizeof(PJRT_Error_Destroy_Args);
+  args.error = err;
+  api->PJRT_Error_Destroy_(&args);
+}
+
 void check_err(const PJRT_Api *api, PJRT_Error *err) {
   if (err) {
-    PJRT_Error_Message_Args args;
-    args.error = err;
+    PJRT_Error_Message_Args args{};
     args.struct_size = sizeof(PJRT_Error_Message_Args);
+    args.error = err;
     api->PJRT_Error_Message_(&args);
-    throw std::runtime_error(args.message);
+    std::string message(args.message, args.message_size);
+    // The PJRT_Error is owned by the caller and must be destroyed even on the
+    // failure path, before we unwind via the exception.
+    destroy_error(api, err);
+    throw std::runtime_error(message);
   }
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,6 +7,11 @@
 
 void check_err(const PJRT_Api *api, PJRT_Error *err);
 
+// Destroy a PJRT_Error. The error object is owned by the caller of the PJRT C
+// API and must be freed once its message/code has been read; a null error is a
+// no-op.
+void destroy_error(const PJRT_Api *api, PJRT_Error *err);
+
 std::vector<int64_t> dims2strides(std::vector<int64_t> dims, bool row_major);
 
 template <typename src_type, typename dst_type>


### PR DESCRIPTION
## What

`check_err()` reads the message out of a `PJRT_Error` and throws an R error, but never called `PJRT_Error_Destroy` on it. The error object is owned by the caller of the PJRT C API, so **every surfaced plugin error leaked** the error object.

## Changes

- Add a `destroy_error()` helper (`src/utils.{h,cpp}`).
- `check_err()` now frees the `PJRT_Error` via `destroy_error()` before unwinding via the exception.
- Read the message with its explicit `message_size` rather than assuming NUL-termination.
- Opens the `0.4.0.9000` development cycle (`DESCRIPTION` + `NEWS.md`).

## Notes

First in a series splitting a large memory-management branch into focused PRs. Foundational: later PRs (gc-on-OOM retry) build on `destroy_error`. `get_error_code` is intentionally **not** here — it's only used by the gc-retry, so it lands with that PR.

## Verification

- Builds clean; `make format` clean (C++ + R).
- All 15 test files pass.
- A malformed program surfaces a clean R error with its message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)