### PR TITLE
chore: adopt roxygen2 8.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,6 @@ Config/build/compilation-database: true
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 SystemRequirements: C++20, libprotobuf, protobuf-compiler
 Collate:
     'RcppExports.R'
@@ -53,3 +52,4 @@ Collate:
     'safetensors.R'
     'utils.R'
     'zzz.R'
+Config/roxygen2/version: 8.0.0

--- a/man/pjrt-package.Rd
+++ b/man/pjrt-package.Rd
@@ -82,6 +82,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Sebastian Fischer \email{seb.fischer@tutamail.com} (\href{https://orcid.org/0000-0002-9609-3197}{ORCID})
   \item Daniel Falbel \email{daniel@posit.co} (\href{https://orcid.org/0009-0006-0143-2392}{ORCID})
 }
 

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -15,6 +15,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{tengen}{\code{\link[tengen]{as_array}}, \code{\link[tengen]{as_raw}}, \code{\link[tengen]{device}}, \code{\link[tengen]{dtype}}, \code{\link[tengen]{shape}}}
+  \item{tengen}{\code{\link[tengen:as_array]{as_array()}}, \code{\link[tengen:as_raw]{as_raw()}}, \code{\link[tengen:device]{device()}}, \code{\link[tengen:dtype]{dtype()}}, \code{\link[tengen:shape]{shape()}}}
 }}
 


### PR DESCRIPTION
Regenerate documentation with **roxygen2 8.0.0**.

- `DESCRIPTION`: `RoxygenNote: 7.3.3` → `Config/roxygen2/version: 8.0.0`.
- `man/pjrt-package.Rd`, `man/reexports.Rd`: updated to the 8.0.0 cross-package `\link[pkg:topic]{topic()}` format.

No code or behaviour change — pure doc regeneration so `devtools::document()` stops producing spurious diffs against the older roxygen2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)