### PR TITLE
feat: layout-aware readback (respect non-row-major device layout)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 * `check_err()` no longer leaks the underlying `PJRT_Error` when
   converting a plugin error into an R exception.
+* Reading a buffer back to the host now respects the device buffer's
+  actual memory layout. A non-row-major (but untiled) executable output —
+  e.g. one pinned to a column-major layout via `mhlo.layout_mode` — is
+  reordered correctly instead of being returned transposed. A layout the
+  readback cannot faithfully reorder (strided, tiled, or rank-mismatched)
+  now raises a clear error rather than silently returning wrong data.
 
 ## Features
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -173,8 +173,8 @@ impl_process_pending_releases <- function() {
     invisible(.Call(`_pjrt_impl_process_pending_releases`))
 }
 
-impl_raw_to_array <- function(host_data, dtype, dims) {
-    .Call(`_pjrt_impl_raw_to_array`, host_data, dtype, dims)
+impl_raw_to_array <- function(host_data, dtype, dims, minor_to_major) {
+    .Call(`_pjrt_impl_raw_to_array`, host_data, dtype, dims, minor_to_major)
 }
 
 impl_buffer_to_host_async <- function(buffer) {

--- a/R/async.R
+++ b/R/async.R
@@ -61,13 +61,16 @@ is_ready.PJRTBuffer <- function(x, ...) {
 #' @param data XPtr to PJRTHostData holding raw bytes and completion event.
 #' @param dtype Element type string (e.g., "f32", "i32").
 #' @param shape Integer vector of dimensions.
+#' @param minor_to_major Integer vector giving the device buffer's layout
+#'   (minor-to-major dimension order), used to reorder the bytes on readback.
 #' @return A `PJRTArrayPromise` object.
 #' @keywords internal
-pjrt_array_promise <- function(data, dtype, shape) {
+pjrt_array_promise <- function(data, dtype, shape, minor_to_major) {
   env <- new.env(parent = emptyenv())
   env$data <- data
   env$dtype <- dtype
   env$shape <- shape
+  env$minor_to_major <- minor_to_major
   env$materialized <- NULL
   structure(env, class = "PJRTArrayPromise")
 }
@@ -76,7 +79,7 @@ pjrt_array_promise <- function(data, dtype, shape) {
 value.PJRTArrayPromise <- function(x, ...) {
   if (is.null(x$materialized)) {
     impl_host_data_await(x$data)
-    out <- impl_raw_to_array(x$data, x$dtype, x$shape)
+    out <- impl_raw_to_array(x$data, x$dtype, x$shape, x$minor_to_major)
     if (x$dtype %in% c("i64", "ui64", "ui32")) {
       class(out) <- "integer64"
     }

--- a/R/buffer.R
+++ b/R/buffer.R
@@ -511,7 +511,7 @@ as_array_async <- function(x, ...) {
 #' @export
 as_array_async.PJRTBuffer <- function(x, ...) {
   result <- impl_buffer_to_host_async(x)
-  pjrt_array_promise(result$data, result$dtype, result$dims)
+  pjrt_array_promise(result$data, result$dtype, result$dims, result$minor_to_major)
 }
 
 

--- a/man/pjrt_array_promise.Rd
+++ b/man/pjrt_array_promise.Rd
@@ -4,7 +4,7 @@
 \alias{pjrt_array_promise}
 \title{Create a PJRT Array Promise (internal)}
 \usage{
-pjrt_array_promise(data, dtype, shape)
+pjrt_array_promise(data, dtype, shape, minor_to_major)
 }
 \arguments{
 \item{data}{XPtr to PJRTHostData holding raw bytes and completion event.}
@@ -12,6 +12,9 @@ pjrt_array_promise(data, dtype, shape)
 \item{dtype}{Element type string (e.g., "f32", "i32").}
 
 \item{shape}{Integer vector of dimensions.}
+
+\item{minor_to_major}{Integer vector giving the device buffer's layout
+(minor-to-major dimension order), used to reorder the bytes on readback.}
 }
 \value{
 A \code{PJRTArrayPromise} object.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -498,15 +498,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // impl_raw_to_array
-SEXP impl_raw_to_array(Rcpp::XPtr<rpjrt::PJRTHostData> host_data, const std::string& dtype, Rcpp::IntegerVector dims);
-RcppExport SEXP _pjrt_impl_raw_to_array(SEXP host_dataSEXP, SEXP dtypeSEXP, SEXP dimsSEXP) {
+SEXP impl_raw_to_array(Rcpp::XPtr<rpjrt::PJRTHostData> host_data, const std::string& dtype, Rcpp::IntegerVector dims, Rcpp::IntegerVector minor_to_major);
+RcppExport SEXP _pjrt_impl_raw_to_array(SEXP host_dataSEXP, SEXP dtypeSEXP, SEXP dimsSEXP, SEXP minor_to_majorSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::XPtr<rpjrt::PJRTHostData> >::type host_data(host_dataSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type dtype(dtypeSEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type dims(dimsSEXP);
-    rcpp_result_gen = Rcpp::wrap(impl_raw_to_array(host_data, dtype, dims));
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type minor_to_major(minor_to_majorSEXP);
+    rcpp_result_gen = Rcpp::wrap(impl_raw_to_array(host_data, dtype, dims, minor_to_major));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -699,7 +700,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_pjrt_impl_host_data_is_ready", (DL_FUNC) &_pjrt_impl_host_data_is_ready, 1},
     {"_pjrt_impl_host_data_await", (DL_FUNC) &_pjrt_impl_host_data_await, 1},
     {"_pjrt_impl_process_pending_releases", (DL_FUNC) &_pjrt_impl_process_pending_releases, 0},
-    {"_pjrt_impl_raw_to_array", (DL_FUNC) &_pjrt_impl_raw_to_array, 3},
+    {"_pjrt_impl_raw_to_array", (DL_FUNC) &_pjrt_impl_raw_to_array, 4},
     {"_pjrt_impl_buffer_to_host_async", (DL_FUNC) &_pjrt_impl_buffer_to_host_async, 1},
     {"_pjrt_impl_loaded_executable_execute", (DL_FUNC) &_pjrt_impl_loaded_executable_execute, 3},
     {"_pjrt_impl_client_buffer_from_integer", (DL_FUNC) &_pjrt_impl_client_buffer_from_integer, 5},

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -127,6 +127,57 @@ std::unique_ptr<PJRTBufferMemoryLayout> PJRTBuffer::memory_layout() {
   return std::make_unique<PJRTBufferMemoryLayout>(args.layout);
 }
 
+std::vector<int64_t> PJRTBuffer::minor_to_major() {
+  const auto ndim = dimensions().size();
+
+  // For scalars and vectors there is only one possible element order, and
+  // readback treats them as dense, so the physical layout is irrelevant.
+  // Return the trivial row-major permutation without inspecting the layout —
+  // this also means an exotic-but-irrelevant layout never blocks a 0-D/1-D
+  // readback.
+  std::vector<int64_t> row_major(ndim);
+  for (size_t i = 0; i < ndim; ++i) {
+    row_major[i] = static_cast<int64_t>(ndim - 1 - i);
+  }
+  if (ndim <= 1) return row_major;
+
+  PJRT_Buffer_GetMemoryLayout_Args args{};
+  args.struct_size = sizeof(PJRT_Buffer_GetMemoryLayout_Args);
+  args.buffer = this->buffer;
+  check_err(this->api.get(), this->api->PJRT_Buffer_GetMemoryLayout_(&args));
+
+  // Our readback can only faithfully reorder a dense, untiled layout expressed
+  // as a minor-to-major permutation. The other representations would require
+  // machinery we don't implement — stride-walking for a strided layout, or
+  // de-tiling (which also changes the physical byte count via padding) for a
+  // tiled one — so we error rather than silently returning wrong data.
+  //
+  // In practice none of these occur on the platforms pjrt supports: CPU, CUDA,
+  // and Metal all hand back dense untiled layouts (tiling is a TPU feature).
+  // The checks therefore only fire if a future/exotic backend produces a
+  // layout we cannot honor, turning silent corruption into a clear error.
+  if (args.layout.type != PJRT_Buffer_MemoryLayout_Type_Tiled) {
+    Rcpp::stop(
+        "Unsupported strided buffer memory layout on readback; only dense "
+        "untiled layouts are supported (CPU/CUDA/Metal).");
+  }
+  if (args.layout.tiled.num_tiles > 0) {
+    Rcpp::stop(
+        "Unsupported tiled buffer memory layout on readback; only dense "
+        "untiled layouts are supported (tiling is a TPU feature, which pjrt "
+        "does not support).");
+  }
+  if (args.layout.tiled.minor_to_major_size != ndim) {
+    Rcpp::stop(
+        "Buffer memory layout rank (%d) does not match buffer rank (%d).",
+        static_cast<int>(args.layout.tiled.minor_to_major_size),
+        static_cast<int>(ndim));
+  }
+  return std::vector<int64_t>(
+      args.layout.tiled.minor_to_major,
+      args.layout.tiled.minor_to_major + args.layout.tiled.minor_to_major_size);
+}
+
 PJRT_Buffer_Type PJRTBuffer::element_type() {
   PJRT_Buffer_ElementType_Args args{};
   args.struct_size = sizeof(PJRT_Buffer_ElementType_Args);
@@ -153,7 +204,9 @@ std::unique_ptr<PJRTEvent> PJRTBuffer::buffer_to_host_async(
   args.dst = host_buffer.data();
   args.dst_size = host_buffer.size();
 
-  // Start the copy but don't wait
+  // Start the copy but don't wait. The bytes arrive in the buffer's *device*
+  // layout (the CPU runtime ignores a requested host_layout), so callers must
+  // consult minor_to_major() to interpret them; see device_to_row_major().
   check_err(this->api.get(), this->api->PJRT_Buffer_ToHostBuffer_(&args));
 
   // Return the event - caller is responsible for waiting and keeping

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -52,6 +52,11 @@ class PJRTBuffer {
   std::vector<int64_t> dimensions();
   std::unique_ptr<PJRTMemory> memory();
   std::unique_ptr<PJRTBufferMemoryLayout> memory_layout();
+  // The buffer's dense layout as a minor-to-major permutation of logical
+  // dimensions (minor_to_major[0] = fastest-varying dim). Row-major is
+  // [n-1, ..., 0]; column-major is [0, ..., n-1]. Used to interpret the bytes
+  // from buffer_to_host_async, which arrive in the device layout.
+  std::vector<int64_t> minor_to_major();
   PJRT_Buffer_Type element_type();
   std::unique_ptr<PJRTDevice> device();
   std::shared_ptr<PJRT_Api> get_api() const { return api; }

--- a/src/deferred_release.h
+++ b/src/deferred_release.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <cstddef>
-
 #include <Rcpp.h>
+
+#include <cstddef>
 
 namespace rpjrt {
 

--- a/src/pjrt.cpp
+++ b/src/pjrt.cpp
@@ -294,7 +294,8 @@ Rcpp::XPtr<rpjrt::PJRTBuffer> impl_client_buffer_from_raw(
 // casting. Used by both sync and async buffer-to-host paths.
 template <typename T>
 SEXP raw_to_array_impl(const uint8_t *raw_data,
-                       const std::vector<int64_t> &dimensions, int r_type) {
+                       const std::vector<int64_t> &dimensions, int r_type,
+                       const std::vector<int64_t> &minor_to_major) {
   const auto numel = number_of_elements(dimensions);
 
   if (numel == 0) {
@@ -307,9 +308,12 @@ SEXP raw_to_array_impl(const uint8_t *raw_data,
     return out;
   }
 
-  // Reinterpret raw bytes as typed data and copy to vector for transpose
+  // Reinterpret the device-layout bytes and reorder them to logical row-major
+  // (a no-op copy when the device layout is already row-major).
   const T *typed_data = reinterpret_cast<const T *>(raw_data);
-  std::vector<T> temp_vec(typed_data, typed_data + numel);
+  std::vector<T> temp_vec(numel);
+  device_to_row_major<T>(typed_data, temp_vec.data(), dimensions,
+                         minor_to_major);
 
   SEXP out = PROTECT(Rf_allocVector(r_type, numel));
   void *out_data;
@@ -373,10 +377,13 @@ Rcpp::RawVector impl_buffer_to_raw(Rcpp::XPtr<rpjrt::PJRTClient> client,
 
   Rcpp::RawVector raw_data(total_bytes);
 
-  if (row_major || format_is_irrelevant(dimensions)) {
-    // optimization: we don't need a temporary buffer because
-    // 1. We don't need to cast the data
-    // 2. We don't need to transpose the data
+  // The bytes from PJRT arrive in the device layout. When that layout already
+  // matches what the caller wants — row-major requested and device is
+  // row-major, or the layout is irrelevant (e.g. 1-D) — we can copy straight
+  // into the output with no temporary or reorder.
+  const auto minor_to_major = buffer->minor_to_major();
+  const bool device_row_major = is_row_major(minor_to_major);
+  if (format_is_irrelevant(dimensions) || (row_major && device_row_major)) {
     std::span<uint8_t> host_buffer(
         reinterpret_cast<uint8_t *>(raw_data.begin()), total_bytes);
     auto event = buffer->buffer_to_host_async(host_buffer);
@@ -387,18 +394,29 @@ Rcpp::RawVector impl_buffer_to_raw(Rcpp::XPtr<rpjrt::PJRTClient> client,
     return raw_data;
   }
 
+  // Otherwise read the device-layout bytes into a temporary, normalize them to
+  // logical row-major, then emit the requested order (row-major as-is, or
+  // column-major via a transpose).
   auto handle_transpose = [&](auto type_tag) {
     using T = decltype(type_tag);
-    std::vector<T> temp_vec(numel);
-    std::span<uint8_t> host_buffer(reinterpret_cast<uint8_t *>(temp_vec.data()),
-                                   total_bytes);
+    std::vector<T> device_vec(numel);
+    std::span<uint8_t> host_buffer(
+        reinterpret_cast<uint8_t *>(device_vec.data()), total_bytes);
     auto event = buffer->buffer_to_host_async(host_buffer);
     if (event) {
       event->await();
       event->check_error();
     }
-    row_to_col_order<T, T>(temp_vec, reinterpret_cast<T *>(raw_data.begin()),
-                           dimensions);
+    std::vector<T> row_major_vec(numel);
+    device_to_row_major<T>(device_vec.data(), row_major_vec.data(), dimensions,
+                           minor_to_major);
+    if (row_major) {
+      std::copy(row_major_vec.begin(), row_major_vec.end(),
+                reinterpret_cast<T *>(raw_data.begin()));
+    } else {
+      row_to_col_order<T, T>(
+          row_major_vec, reinterpret_cast<T *>(raw_data.begin()), dimensions);
+    }
   };
 
   switch (element_type) {
@@ -646,8 +664,10 @@ void impl_process_pending_releases() { rpjrt::process_pending_releases(); }
 
 // [[Rcpp::export()]]
 SEXP impl_raw_to_array(Rcpp::XPtr<rpjrt::PJRTHostData> host_data,
-                       const std::string &dtype, Rcpp::IntegerVector dims) {
+                       const std::string &dtype, Rcpp::IntegerVector dims,
+                       Rcpp::IntegerVector minor_to_major) {
   std::vector<int64_t> dimensions(dims.begin(), dims.end());
+  std::vector<int64_t> m2m(minor_to_major.begin(), minor_to_major.end());
 
   // Handle null/empty data
   const uint8_t *raw_data = nullptr;
@@ -656,30 +676,30 @@ SEXP impl_raw_to_array(Rcpp::XPtr<rpjrt::PJRTHostData> host_data,
   }
 
   if (dtype == "f32") {
-    return raw_to_array_impl<float>(raw_data, dimensions, REALSXP);
+    return raw_to_array_impl<float>(raw_data, dimensions, REALSXP, m2m);
   } else if (dtype == "f64") {
-    return raw_to_array_impl<double>(raw_data, dimensions, REALSXP);
+    return raw_to_array_impl<double>(raw_data, dimensions, REALSXP, m2m);
   } else if (dtype == "i8") {
-    return raw_to_array_impl<int8_t>(raw_data, dimensions, INTSXP);
+    return raw_to_array_impl<int8_t>(raw_data, dimensions, INTSXP, m2m);
   } else if (dtype == "i16") {
-    return raw_to_array_impl<int16_t>(raw_data, dimensions, INTSXP);
+    return raw_to_array_impl<int16_t>(raw_data, dimensions, INTSXP, m2m);
   } else if (dtype == "i32") {
-    return raw_to_array_impl<int32_t>(raw_data, dimensions, INTSXP);
+    return raw_to_array_impl<int32_t>(raw_data, dimensions, INTSXP, m2m);
   } else if (dtype == "i64") {
-    return raw_to_array_impl<int64_t>(raw_data, dimensions, REALSXP);
+    return raw_to_array_impl<int64_t>(raw_data, dimensions, REALSXP, m2m);
   } else if (dtype == "ui8") {
-    return raw_to_array_impl<uint8_t>(raw_data, dimensions, INTSXP);
+    return raw_to_array_impl<uint8_t>(raw_data, dimensions, INTSXP, m2m);
   } else if (dtype == "ui16") {
-    return raw_to_array_impl<uint16_t>(raw_data, dimensions, INTSXP);
+    return raw_to_array_impl<uint16_t>(raw_data, dimensions, INTSXP, m2m);
   } else if (dtype == "ui32") {
     // u32 -> integer64 storage: signed int32 has no headroom for ui32 values
     // >= 2^31; widen to integer64 (53 bits of headroom) so the R caller gets
     // the full unsigned magnitude. R-side classes the result as integer64.
-    return raw_to_array_impl<uint32_t>(raw_data, dimensions, REALSXP);
+    return raw_to_array_impl<uint32_t>(raw_data, dimensions, REALSXP, m2m);
   } else if (dtype == "ui64") {
-    return raw_to_array_impl<uint64_t>(raw_data, dimensions, REALSXP);
+    return raw_to_array_impl<uint64_t>(raw_data, dimensions, REALSXP, m2m);
   } else if (dtype == "pred") {
-    return raw_to_array_impl<uint8_t>(raw_data, dimensions, LGLSXP);
+    return raw_to_array_impl<uint8_t>(raw_data, dimensions, LGLSXP, m2m);
   } else {
     Rcpp::stop("Unsupported dtype: %s", dtype.c_str());
   }
@@ -697,6 +717,11 @@ Rcpp::List impl_buffer_to_host_async(Rcpp::XPtr<rpjrt::PJRTBuffer> buffer) {
 
   Rcpp::IntegerVector dims(dimensions.begin(), dimensions.end());
 
+  // The bytes arrive in the device layout; carry it through so value() can
+  // reorder them to a column-major R array.
+  const auto m2m_vec = buffer->minor_to_major();
+  Rcpp::IntegerVector minor_to_major(m2m_vec.begin(), m2m_vec.end());
+
   // Handle empty buffers
   if (numel == 0) {
     auto empty_vec = std::make_unique<std::vector<uint8_t>>();
@@ -705,7 +730,8 @@ Rcpp::List impl_buffer_to_host_async(Rcpp::XPtr<rpjrt::PJRTBuffer> buffer) {
     Rcpp::XPtr<rpjrt::PJRTHostData> data_xptr(empty_data.release(), true);
     return Rcpp::List::create(Rcpp::Named("data") = data_xptr,
                               Rcpp::Named("dtype") = dtype,
-                              Rcpp::Named("dims") = dims);
+                              Rcpp::Named("dims") = dims,
+                              Rcpp::Named("minor_to_major") = minor_to_major);
   }
 
   const size_t total_bytes = numel * sizeof_pjrt_buffer_type(element_type);
@@ -723,7 +749,8 @@ Rcpp::List impl_buffer_to_host_async(Rcpp::XPtr<rpjrt::PJRTBuffer> buffer) {
 
   return Rcpp::List::create(Rcpp::Named("data") = data_xptr,
                             Rcpp::Named("dtype") = dtype,
-                            Rcpp::Named("dims") = dims);
+                            Rcpp::Named("dims") = dims,
+                            Rcpp::Named("minor_to_major") = minor_to_major);
 }
 
 static std::string device_to_string(PJRT_Device *device, PJRT_Api *api) {

--- a/src/pjrt.cpp
+++ b/src/pjrt.cpp
@@ -942,8 +942,8 @@ Rcpp::List impl_loaded_executable_execute(
   // input alive until the computation finishes with it. Pinning the whole XPtr
   // keeps the buffer -- and transitively its RAWSXP -- reachable, so an
   // un-awaited Execute can't read freed memory. Device inputs (CUDA/Metal) are
-  // PJRT-owned and carry a NilValue prot slot, so they are skipped: PJRT already
-  // defers their device-memory free until pending ops complete.
+  // PJRT-owned and carry a NilValue prot slot, so they are skipped: PJRT
+  // already defers their device-memory free until pending ops complete.
   std::vector<SEXP> input_keepalives;
   for (auto i = 0; i < input.size(); ++i) {
     SEXP xptr = VECTOR_ELT(input, i);
@@ -955,8 +955,8 @@ Rcpp::List impl_loaded_executable_execute(
   // Pin the inputs BEFORE launching the async Execute, so the keepalive is
   // already in place when PJRT's background threads begin reading the aliased
   // host bytes. R_PreserveObject runs here on the main thread; the matching
-  // release is deferred to the completion event below. If Execute itself throws,
-  // unpin first so the objects don't leak.
+  // release is deferred to the completion event below. If Execute itself
+  // throws, unpin first so the objects don't leak.
   for (SEXP k : input_keepalives) R_PreserveObject(k);
 
   rpjrt::AsyncExecuteResult result;
@@ -987,9 +987,11 @@ Rcpp::List impl_loaded_executable_execute(
   const auto &aliases = executable->input_output_aliases();
   for (const auto &alias : aliases) {
     if (alias.input_index < 0 ||
-        static_cast<size_t>(alias.input_index) >= static_cast<size_t>(input.size()) ||
+        static_cast<size_t>(alias.input_index) >=
+            static_cast<size_t>(input.size()) ||
         alias.output_index < 0 ||
-        static_cast<size_t>(alias.output_index) >= static_cast<size_t>(buffers.size())) {
+        static_cast<size_t>(alias.output_index) >=
+            static_cast<size_t>(buffers.size())) {
       continue;
     }
     SEXP in_xptr_sexp = VECTOR_ELT(input, alias.input_index);
@@ -1007,8 +1009,8 @@ Rcpp::List impl_loaded_executable_execute(
   // Release the input keepalives (pinned before Execute, above) once the
   // execution has finished reading all inputs. Without the pin, a dropped
   // zero-copy input could be collected -- freeing its backing RAWSXP -- while
-  // the async Execute is still reading it (use-after-free). The completion event
-  // fires on a PJRT thread and only enqueues the release; the actual
+  // the async Execute is still reading it (use-after-free). The completion
+  // event fires on a PJRT thread and only enqueues the release; the actual
   // R_ReleaseObject runs later on the main thread via the deferred-release
   // queue. The PJRTEvent wrapper is destroyed when `result` goes out of scope,
   // but the registered callback still fires (see PJRTEvent::on_ready).
@@ -1090,9 +1092,9 @@ Rcpp::XPtr<rpjrt::PJRTBuffer> impl_client_buffer_from_integer64(
   } else {
     Rcpp::stop("Unsupported type: %s", dtype.c_str());
   }
-  return create_buffer_from_array_async_no_convert(client, data, REAL(data), dims,
-                                                 buffer_type, sizeof(int64_t),
-                                                 false, device->device);
+  return create_buffer_from_array_async_no_convert(
+      client, data, REAL(data), dims, buffer_type, sizeof(int64_t), false,
+      device->device);
 }
 
 // [[Rcpp::export()]]

--- a/src/utils.h
+++ b/src/utils.h
@@ -113,6 +113,49 @@ void row_to_col_order(const std::vector<src_type> &src, dst_type *dst,
   }
 }
 
+// True if `minor_to_major` is the dense row-major order [n-1, ..., 1, 0]
+// (last logical dimension fastest-varying), the layout our readback assumes.
+inline bool is_row_major(const std::vector<int64_t> &minor_to_major) {
+  const int64_t n = minor_to_major.size();
+  for (int64_t k = 0; k < n; ++k) {
+    if (minor_to_major[k] != n - 1 - k) return false;
+  }
+  return true;
+}
+
+// Reorder `total` elements from the device physical order described by
+// `minor_to_major` (minor_to_major[0] = fastest-varying logical dim) into
+// logical row-major order. A no-op copy when the layout is already row-major,
+// so the common path costs nothing extra. `src` and `dst` must not alias.
+template <typename T>
+void device_to_row_major(const T *src, T *dst, const std::vector<int64_t> &dims,
+                         const std::vector<int64_t> &minor_to_major) {
+  const int64_t n = dims.size();
+  int64_t total = 1;
+  for (int64_t d : dims) total *= d;
+  if (n <= 1 || is_row_major(minor_to_major)) {
+    std::copy(src, src + total, dst);
+    return;
+  }
+  // Physical stride of each logical dimension, derived from minor_to_major.
+  std::vector<int64_t> phys(n, 1);
+  int64_t acc = 1;
+  for (int64_t k = 0; k < n; ++k) {
+    phys[minor_to_major[k]] = acc;
+    acc *= dims[minor_to_major[k]];
+  }
+  const std::vector<int64_t> row = dims2strides(dims, /*row_major=*/true);
+  for (int64_t r = 0; r < total; ++r) {
+    int64_t tmp = r, p = 0;
+    for (int64_t d = 0; d < n; ++d) {
+      const int64_t coord = tmp / row[d];
+      tmp %= row[d];
+      p += coord * phys[d];
+    }
+    dst[r] = src[p];
+  }
+}
+
 size_t sizeof_pjrt_buffer_type(PJRT_Buffer_Type type);
 
 bool format_is_irrelevant(const std::vector<int64_t> &dims);

--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -1054,3 +1054,25 @@ describe("copy_buffer", {
     expect_equal(dtype(buf2), dtype(buf))
   })
 })
+
+test_that("as_array respects a non-row-major executable output layout", {
+  skip_if(!is_cpu())
+  # Pin a column-major output layout via `mhlo.layout_mode = "{0,1}"` on the
+  # function result (default is row-major, `{1,0}`). The device buffer is then
+  # NOT row-major; readback must still return the correct logical matrix rather
+  # than a transposed/garbled one.
+  mlir <- '
+module {
+  func.func @main(%arg0: tensor<2x3xf32>) -> (tensor<2x3xf32> {mhlo.layout_mode = "{0,1}"}) {
+    return %arg0 : tensor<2x3xf32>
+  }
+}
+'
+  prog <- pjrt_program(src = mlir, format = "mlir")
+  exec <- pjrt_compile(prog, device = "cpu")
+  m <- matrix(as.double(1:6), nrow = 2, ncol = 3)
+  out <- pjrt_execute(exec, pjrt_buffer(m, dtype = "f32"))
+  expect_equal(as_array(out), m, tolerance = 1e-6)
+  # as_raw goes through the same device→host path, so it must agree too.
+  expect_equal(as_raw(out, row_major = FALSE), as_raw(pjrt_buffer(m, dtype = "f32"), row_major = FALSE))
+})

--- a/tools/stress-cpu-memory.R
+++ b/tools/stress-cpu-memory.R
@@ -364,7 +364,13 @@ ka_collected$fired <- FALSE
 # ka_x is an external pointer, so it can carry a finalizer; it fires when ka_x is
 # garbage collected -- which pjrt_execute must prevent until the execution that
 # reads it completes.
-reg.finalizer(ka_x, function(e) ka_collected$fired <- TRUE, onexit = FALSE)
+reg.finalizer(
+  ka_x,
+  function(e) {
+    ka_collected$fired <- TRUE
+  },
+  onexit = FALSE
+)
 
 ka_out <- pjrt_execute(ka_exec, ka_x, ka_ones)
 rm(ka_x)


### PR DESCRIPTION
## Summary

`PJRT_Buffer_ToHostBuffer` hands back bytes in the buffer's own device layout, which is usually — but not guaranteed — row-major. An executable output can be pinned to another layout (e.g. column-major via `mhlo.layout_mode`), and the CPU runtime ignores a requested `host_layout`, so readback has to respect the device layout itself rather than assuming row-major. Previously a non-row-major output was silently returned transposed/garbled.

`PJRTBuffer::minor_to_major()` queries `PJRT_Buffer_GetMemoryLayout` and returns the dense minor-to-major permutation. `device_to_row_major()` / `is_row_major()` (in `utils.h`) invert *any* permutation back to logical row-major — a no-op copy on the common row-major path, so the hot path costs nothing extra. This is threaded through `impl_buffer_to_raw`, `impl_buffer_to_host_async`, `impl_raw_to_array`, and the `PJRTArrayPromise` (which now carries `minor_to_major` so `value()` can reorder on materialization).

Layouts the readback cannot faithfully reorder — strided, tiled (`num_tiles > 0`, a TPU feature), or rank-mismatched, none of which occur on CPU/CUDA/Metal — now raise a clear error instead of silently returning wrong data.

## Verification

New regression test `as_array respects a non-row-major executable output layout` (`tests/testthat/test-buffer.R`) compiles an identity function whose result is pinned column-major via `mhlo.layout_mode = "{0,1}"` and checks the matrix round-trips through both `as_array()` and `as_raw()`:

```r
mlir <- '
module {
  func.func @main(%arg0: tensor<2x3xf32>) -> (tensor<2x3xf32> {mhlo.layout_mode = "{0,1}"}) {
    return %arg0 : tensor<2x3xf32>
  }
}
'
exec <- pjrt_compile(pjrt_program(src = mlir, format = "mlir"), device = "cpu")
m <- matrix(as.double(1:6), nrow = 2, ncol = 3)
out <- pjrt_execute(exec, pjrt_buffer(m, dtype = "f32"))
stopifnot(all.equal(as_array(out), m))
```

Full local test suite: 0 failures, 502 passing (CUDA/Metal/CRAN-gated tests skipped). `jarl check` clean; `make format` a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)