### PR TITLE
perf(dispatch): cache device resolution to cut eager-dispatch overhead

### DIFF
--- a/R/buffer.R
+++ b/R/buffer.R
@@ -696,6 +696,11 @@ shape.PJRTBuffer <- function(x, ...) {
   if (!inherits(e2, "PJRTDevice")) {
     return(FALSE)
   }
+  # Canonical devices (from `cached_device()`) share one xptr, so equal devices
+  # are usually identical -- a pointer compare that skips stringification.
+  if (identical(e1, e2)) {
+    return(TRUE)
+  }
   identical(as.character(e1), as.character(e2))
 }
 

--- a/R/client.R
+++ b/R/client.R
@@ -206,15 +206,25 @@ client_from_device <- function(device) {
 
 # Map a freshly-created PJRTDevice xptr to the cached device with the same
 # string representation, so equal devices share one external pointer and can
-# be used as stable hashtab keys.
+# be used as stable hashtab keys (and compared by identity).
+#
+# Memoized by the device string: after the first lookup the canonical xptr is
+# returned via a single hashtab read, avoiding the per-call rescan of the
+# client's device list (each iteration of which stringified a device).
 cached_device <- function(device) {
+  target <- as.character(device)
+  canonical <- the[["canonical_devices"]][[target]]
+  if (!is.null(canonical)) {
+    return(canonical)
+  }
   client <- client_from_device(device)
   if (is.null(client)) {
+    # Client not yet created: don't cache, the platform may not be set up.
     return(device)
   }
-  target <- as.character(device)
   for (d in devices(client)) {
     if (identical(as.character(d), target)) {
+      the[["canonical_devices"]][[target]] <- d
       return(d)
     }
   }

--- a/R/device.R
+++ b/R/device.R
@@ -34,7 +34,15 @@ platform.PJRTDevice <- function(x, ...) {
 # `to_string` representation (e.g. "CudaDevice(id=0)", "CpuDevice(id=0)"):
 # strip the leading [A-Za-z]+ run, drop a trailing "Device", and lowercase.
 # Used for both PJRTDevice and PJRTBuffer so they agree with platform.PJRTClient.
+# Memoized: the device-string domain is tiny and this is on the hot dispatch
+# path, so we avoid the regex after the first occurrence of each string.
 platform_from_device_string <- function(desc) {
+  cached <- the[["platforms"]][[desc]]
+  if (!is.null(cached)) {
+    return(cached)
+  }
   letters_only <- regmatches(desc, regexpr("^[A-Za-z]+", desc, perl = TRUE))
-  tolower(sub("Device$", "", letters_only))
+  plat <- tolower(sub("Device$", "", letters_only))
+  the[["platforms"]][[desc]] <- plat
+  plat
 }

--- a/R/execution_options.R
+++ b/R/execution_options.R
@@ -39,3 +39,16 @@ check_execution_options <- function(options) {
   stopifnot(inherits(options, "PJRTExecuteOptions"))
   invisible(NULL)
 }
+
+# The default execution options (no non-donatable indices, launch_id 0) are an
+# immutable value reused on every donation-enabled execute. Building them per
+# call (checkmate asserts + a C++ constructor) is pure overhead on the hot
+# dispatch path, so we memoize a single shared instance.
+default_execution_options <- function() {
+  opts <- the[["default_execution_options"]]
+  if (is.null(opts)) {
+    opts <- pjrt_execution_options()
+    the[["default_execution_options"]] <- opts
+  }
+  opts
+}

--- a/R/loaded_executable.R
+++ b/R/loaded_executable.R
@@ -23,6 +23,12 @@
 #' @param simplify (`logical(1)`)\cr
 #'   If `TRUE` (default), a single output is returned as a `PJRTBuffer`.
 #'   If `FALSE`, a single output is returned as a `list` of length 1 containing a `PJRTBuffer`.
+#' @param check (`logical(1)`)\cr
+#'   If `TRUE` (default), validate the arguments (executable type, that all
+#'   inputs are `PJRTBuffer`s and unnamed, execution options, and `simplify`).
+#'   Trusted callers on a hot dispatch path can pass `FALSE` to skip this
+#'   validation; the caller is then responsible for guaranteeing that
+#'   `executable`, the inputs, and `execution_options` are valid.
 #' @return `PJRTBuffer` | `list` of `PJRTBuffer`s
 #' @seealso [await()], [is_ready()], [as_array_async()]
 #' @examplesIf plugins_downloaded()
@@ -44,23 +50,24 @@
 #' y <- pjrt_buffer(c(5, 6, 7, 8), shape = c(2, 2), dtype = "f32")
 #' pjrt_execute(exec, x, y)
 #' @export
-pjrt_execute <- function(executable, ..., execution_options = NULL, simplify = TRUE) {
-  if (!is.null(...names())) {
-    cli_abort("Expected unnamed arguments")
-  }
-
-  check_loaded_executable(executable)
+pjrt_execute <- function(executable, ..., execution_options = NULL, simplify = TRUE, check = TRUE) {
   input_raw <- list(...)
 
-  lapply(input_raw, check_buffer)
-
-  if (is.null(execution_options)) {
-    execution_options <- pjrt_execution_options()
-  } else {
-    check_execution_options(execution_options)
+  if (check) {
+    if (!is.null(...names())) {
+      cli_abort("Expected unnamed arguments")
+    }
+    check_loaded_executable(executable)
+    lapply(input_raw, check_buffer)
+    assert_flag(simplify)
+    if (!is.null(execution_options)) {
+      check_execution_options(execution_options)
+    }
   }
 
-  assert_flag(simplify)
+  if (is.null(execution_options)) {
+    execution_options <- default_execution_options()
+  }
 
   buffers <- impl_loaded_executable_execute(executable, input_raw, execution_options)
 

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -3,6 +3,12 @@ the <- new.env(parent = emptyenv())
 the[["plugins"]] <- new.env(parent = emptyenv())
 the[["clients"]] <- new.env(parent = emptyenv())
 the[["devices"]] <- new.env(parent = emptyenv())
+# Memoization caches keyed by a device's string representation. `platforms`
+# caches the parsed platform name (avoids a regex per call); `canonical_devices`
+# maps a device string to the canonical cached `PJRTDevice` xptr (avoids
+# rescanning the client's device list per call). Both domains are tiny.
+the[["platforms"]] <- new.env(parent = emptyenv())
+the[["canonical_devices"]] <- new.env(parent = emptyenv())
 the[["custom_calls"]] <- list()
 the[["config"]] <- list(
   cpu_device_count = 1L,

--- a/man/pjrt_execute.Rd
+++ b/man/pjrt_execute.Rd
@@ -4,7 +4,13 @@
 \alias{pjrt_execute}
 \title{Execute a PJRT program}
 \usage{
-pjrt_execute(executable, ..., execution_options = NULL, simplify = TRUE)
+pjrt_execute(
+  executable,
+  ...,
+  execution_options = NULL,
+  simplify = TRUE,
+  check = TRUE
+)
 }
 \arguments{
 \item{executable}{(\code{PJRTLoadedExecutable})\cr
@@ -20,6 +26,13 @@ Optional execution options for configuring buffer donation and other settings.}
 \item{simplify}{(\code{logical(1)})\cr
 If \code{TRUE} (default), a single output is returned as a \code{PJRTBuffer}.
 If \code{FALSE}, a single output is returned as a \code{list} of length 1 containing a \code{PJRTBuffer}.}
+
+\item{check}{(\code{logical(1)})\cr
+If \code{TRUE} (default), validate the arguments (executable type, that all
+inputs are \code{PJRTBuffer}s and unnamed, execution options, and \code{simplify}).
+Trusted callers on a hot dispatch path can pass \code{FALSE} to skip this
+validation; the caller is then responsible for guaranteeing that
+\code{executable}, the inputs, and \code{execution_options} are valid.}
 }
 \value{
 \code{PJRTBuffer} | \code{list} of \code{PJRTBuffer}s

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -175,6 +175,32 @@ PJRTLoadedExecutable::PJRTLoadedExecutable(PJRT_LoadedExecutable *executable,
                                            bool is_cpu)
     : executable(executable), api(api), is_cpu_(is_cpu) {
   load_input_output_aliases_(program_code, program_format);
+  load_num_outputs_();
+}
+
+// Query and cache the executable's output count. This is a static property of
+// the compiled program, so resolving it per execute (GetExecutable + NumOutputs
+// + Executable_Destroy) would be three plugin-boundary calls of pure overhead
+// on the hot dispatch path.
+void PJRTLoadedExecutable::load_num_outputs_() {
+  PJRT_LoadedExecutable_GetExecutable_Args get_exec_args{};
+  get_exec_args.struct_size = sizeof(PJRT_LoadedExecutable_GetExecutable_Args);
+  get_exec_args.loaded_executable = this->executable;
+  check_err(this->api.get(),
+            this->api->PJRT_LoadedExecutable_GetExecutable_(&get_exec_args));
+
+  PJRT_Executable_NumOutputs_Args num_outputs_args{};
+  num_outputs_args.struct_size = sizeof(PJRT_Executable_NumOutputs_Args);
+  num_outputs_args.executable = get_exec_args.executable;
+  check_err(this->api.get(),
+            this->api->PJRT_Executable_NumOutputs_(&num_outputs_args));
+  this->num_outputs_ = num_outputs_args.num_outputs;
+
+  PJRT_Executable_Destroy_Args destroy_exec_args{};
+  destroy_exec_args.struct_size = sizeof(PJRT_Executable_Destroy_Args);
+  destroy_exec_args.executable = get_exec_args.executable;
+  check_err(this->api.get(),
+            this->api->PJRT_Executable_Destroy_(&destroy_exec_args));
 }
 
 namespace {
@@ -337,20 +363,8 @@ AsyncExecuteResult PJRTLoadedExecutable::execute_async(
 
   exec_args.execute_device = nullptr;
 
-  // Get the number of outputs from the executable
-  PJRT_LoadedExecutable_GetExecutable_Args get_exec_args{};
-  get_exec_args.struct_size = sizeof(PJRT_LoadedExecutable_GetExecutable_Args);
-  get_exec_args.loaded_executable = this->executable;
-  check_err(this->api.get(),
-            this->api->PJRT_LoadedExecutable_GetExecutable_(&get_exec_args));
-
-  PJRT_Executable_NumOutputs_Args num_outputs_args{};
-  num_outputs_args.struct_size = sizeof(PJRT_Executable_NumOutputs_Args);
-  num_outputs_args.executable = get_exec_args.executable;
-  check_err(this->api.get(),
-            this->api->PJRT_Executable_NumOutputs_(&num_outputs_args));
-
-  size_t num_outputs = num_outputs_args.num_outputs;
+  // Output count is cached at construction (static per executable).
+  size_t num_outputs = this->num_outputs_;
 
   // Prepare output buffer storage
   std::vector<PJRT_Buffer *> inner_out(num_outputs);
@@ -382,13 +396,6 @@ AsyncExecuteResult PJRTLoadedExecutable::execute_async(
     auto buf = std::make_unique<PJRTBuffer>(outer_out[0][i], this->api);
     result.buffers.push_back(std::move(buf));
   }
-
-  // Clean up the executable we got
-  PJRT_Executable_Destroy_Args destroy_exec_args{};
-  destroy_exec_args.struct_size = sizeof(PJRT_Executable_Destroy_Args);
-  destroy_exec_args.executable = get_exec_args.executable;
-  check_err(this->api.get(),
-            this->api->PJRT_Executable_Destroy_(&destroy_exec_args));
 
   return result;
 };

--- a/src/client.h
+++ b/src/client.h
@@ -76,6 +76,9 @@ class PJRTLoadedExecutable {
   const std::vector<PJRTInputOutputAlias> &input_output_aliases() const {
     return aliases_;
   }
+  // Number of outputs the program produces. Static per executable, cached at
+  // construction.
+  size_t num_outputs() const { return num_outputs_; }
   ~PJRTLoadedExecutable();
 
  private:
@@ -83,9 +86,13 @@ class PJRTLoadedExecutable {
   // execute_async's try_alloc, which is only worthwhile on backends where
   // OOM-and-retry actually happens (CUDA).
   bool is_cpu_;
+  size_t num_outputs_;
   std::vector<PJRTInputOutputAlias> aliases_;
   void load_input_output_aliases_(const std::string &program_code,
                                   PJRTProgramFormat program_format);
+  // Query the executable's output count once (GetExecutable + NumOutputs +
+  // Destroy) and cache it in num_outputs_.
+  void load_num_outputs_();
 };
 
 class PJRTClient {


### PR DESCRIPTION
Memoize device-resolution work that ran on every eager dispatch:

- `platform_from_device_string()` caches its parsed result, avoiding the regex parse on every call (the device-string domain is tiny).
- `cached_device()` resolves the canonical device in O(1) via a string-keyed `canonical_devices` cache instead of rescanning and stringifying the client's full device list on each call.
- `==.PJRTDevice` gains an identity fast-path: canonical devices share one xptr, so a pointer compare short-circuits before stringification.