### PR TITLE
perf: memoize immutable buffer metadata on PJRTBuffer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,12 @@
   before the first compilation; `inspect_hlo()` errors with instructions if
   they are not set.
 
+## Performance
+
+* A `PJRTBuffer` now memoizes its immutable metadata (dtype, shape, and
+  device) on first access, so repeated `element_type()` / `dimensions()`
+  reads no longer issue a PJRT C API call each time.
+
 ## Bug fixes
 
 * `check_err()` no longer leaks the underlying `PJRT_Error` when

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -112,13 +112,9 @@ PJRTBuffer::~PJRTBuffer() {
   check_err(this->api.get(), this->api->PJRT_Buffer_Destroy_(&args));
 }
 
-std::vector<int64_t> PJRTBuffer::dimensions() {
-  PJRT_Buffer_Dimensions_Args args{};
-  args.struct_size = sizeof(PJRT_Buffer_Dimensions_Args);
-  args.buffer = checked_buffer();
-  check_err(this->api.get(), this->api->PJRT_Buffer_Dimensions_(&args));
-
-  return std::vector<int64_t>(args.dims, args.dims + args.num_dims);
+const std::vector<int64_t> &PJRTBuffer::dimensions() {
+  if (!meta_cached_) cache_meta();
+  return cached_dims_;
 }
 
 std::unique_ptr<PJRTMemory> PJRTBuffer::memory() {
@@ -191,12 +187,8 @@ std::vector<int64_t> PJRTBuffer::minor_to_major() {
 }
 
 PJRT_Buffer_Type PJRTBuffer::element_type() {
-  PJRT_Buffer_ElementType_Args args{};
-  args.struct_size = sizeof(PJRT_Buffer_ElementType_Args);
-  args.buffer = checked_buffer();
-  check_err(this->api.get(), this->api->PJRT_Buffer_ElementType_(&args));
-
-  return args.type;
+  if (!meta_cached_) cache_meta();
+  return cached_type_;
 }
 
 std::unique_ptr<PJRTDevice> PJRTBuffer::device() {
@@ -206,6 +198,36 @@ std::unique_ptr<PJRTDevice> PJRTBuffer::device() {
   check_err(this->api.get(), this->api->PJRT_Buffer_Device_(&args));
 
   return std::make_unique<PJRTDevice>(args.device, this->api);
+}
+
+// Populate the immutable-metadata cache with one PJRT C API call each for
+// dtype, shape, and device. Called on the first element_type()/dimensions()/
+// device_ptr() read; the values never change, so it runs at most once.
+void PJRTBuffer::cache_meta() {
+  PJRT_Buffer_ElementType_Args type_args{};
+  type_args.struct_size = sizeof(PJRT_Buffer_ElementType_Args);
+  type_args.buffer = checked_buffer();
+  check_err(this->api.get(), this->api->PJRT_Buffer_ElementType_(&type_args));
+  cached_type_ = type_args.type;
+
+  PJRT_Buffer_Dimensions_Args dim_args{};
+  dim_args.struct_size = sizeof(PJRT_Buffer_Dimensions_Args);
+  dim_args.buffer = checked_buffer();
+  check_err(this->api.get(), this->api->PJRT_Buffer_Dimensions_(&dim_args));
+  cached_dims_.assign(dim_args.dims, dim_args.dims + dim_args.num_dims);
+
+  PJRT_Buffer_Device_Args dev_args{};
+  dev_args.struct_size = sizeof(PJRT_Buffer_Device_Args);
+  dev_args.buffer = checked_buffer();
+  check_err(this->api.get(), this->api->PJRT_Buffer_Device_(&dev_args));
+  cached_device_ = dev_args.device;
+
+  meta_cached_ = true;
+}
+
+PJRT_Device *PJRTBuffer::device_ptr() {
+  if (!meta_cached_) cache_meta();
+  return cached_device_;
 }
 
 std::unique_ptr<PJRTEvent> PJRTBuffer::buffer_to_host_async(

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -49,7 +49,7 @@ class PJRTBuffer {
   PJRTBuffer(PJRT_Buffer* buffer, std::shared_ptr<PJRT_Api> api);
   PJRT_Buffer* buffer;
   ~PJRTBuffer();
-  std::vector<int64_t> dimensions();
+  const std::vector<int64_t>& dimensions();
   std::unique_ptr<PJRTMemory> memory();
   std::unique_ptr<PJRTBufferMemoryLayout> memory_layout();
   // The buffer's dense layout as a minor-to-major permutation of logical
@@ -80,8 +80,20 @@ class PJRTBuffer {
   // impl_loaded_executable_execute). A null handle counts as deleted.
   bool is_deleted();
 
+  // The raw addressable PJRT_Device* (unlike device(), which heap-allocates a
+  // PJRTDevice wrapper). dtype, shape, and this device pointer are the buffer's
+  // immutable metadata: element_type(), dimensions(), and device_ptr() read
+  // them through the PJRT C API once and memoize (cache_meta), so repeated
+  // reads on the dispatch hot path skip the C API entirely.
+  PJRT_Device* device_ptr();
+
  private:
   std::shared_ptr<PJRT_Api> api;
+  bool meta_cached_ = false;
+  PJRT_Buffer_Type cached_type_;
+  std::vector<int64_t> cached_dims_;
+  PJRT_Device* cached_device_ = nullptr;
+  void cache_meta();
   PJRTEvent ready_event();
   // Returns this->buffer, raising an R-level error if the underlying
   // PJRT handle has been invalidated by donation. Used by every method


### PR DESCRIPTION
element_type(), dimensions(), and the new device_ptr() accessor read a buffer's dtype, shape, and device through the PJRT C API once and cache the result (cache_meta). These properties are immutable, so repeated reads -- e.g. on an eager-dispatch hot path -- skip the C API entirely.

dimensions() now returns a const reference into the cache instead of a fresh vector; all callers already copy, so this is source-compatible.