### PR TITLE
fix: keep C-level stderr out of compiled code

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -101,7 +101,10 @@ StderrCapture begin_stderr_capture() {
   }
   lseek(g_sink_fd, 0, SEEK_SET);
 
-  std::fflush(stderr);
+  // fflush(nullptr) flushes every output stream, stderr included. We must not
+  // name `stderr` here: referencing the C stream symbol in compiled code is
+  // flagged by R CMD check.
+  std::fflush(nullptr);
   int saved = dup(STDERR_FILENO);
   if (saved == -1) {
     return cap;
@@ -118,7 +121,9 @@ void end_stderr_capture(StderrCapture &cap, bool replay) {
   if (cap.saved_fd == -1) {
     return;  // capture was disabled; nothing to restore
   }
-  std::fflush(stderr);  // push any libc-buffered stderr into the sink
+  // Push any libc-buffered stderr into the sink. fflush(nullptr) flushes all
+  // output streams — naming `stderr` would be flagged by R CMD check.
+  std::fflush(nullptr);
   dup2(cap.saved_fd, STDERR_FILENO);
   close(cap.saved_fd);
   cap.saved_fd = -1;
@@ -128,12 +133,12 @@ void end_stderr_capture(StderrCapture &cap, bool replay) {
     char buf[4096];
     ssize_t n;
     while ((n = read(g_sink_fd, buf, sizeof(buf))) > 0) {
-      ssize_t off = 0;
-      while (off < n) {
-        ssize_t w = write(STDERR_FILENO, buf + off, n - off);
-        if (w <= 0) break;
-        off += w;
-      }
+      // Replay through REprintf rather than raw fd-2 writes: package output
+      // must go through R's connections so it reaches GUI consoles and honors
+      // sink(). Requires fd 2 to already be restored (done above), since in
+      // terminal R REprintf itself writes to stderr. %.*s stops at an embedded
+      // NUL, which is fine for log text.
+      REprintf("%.*s", static_cast<int>(n), buf);
     }
   }
   // The sink is left open for reuse; it is reset on the next begin.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -133,12 +133,12 @@ void end_stderr_capture(StderrCapture &cap, bool replay) {
     char buf[4096];
     ssize_t n;
     while ((n = read(g_sink_fd, buf, sizeof(buf))) > 0) {
-      // Replay through REprintf rather than raw fd-2 writes: package output
-      // must go through R's connections so it reaches GUI consoles and honors
-      // sink(). Requires fd 2 to already be restored (done above), since in
-      // terminal R REprintf itself writes to stderr. %.*s stops at an embedded
-      // NUL, which is fine for log text.
-      REprintf("%.*s", static_cast<int>(n), buf);
+      ssize_t off = 0;
+      while (off < n) {
+        ssize_t w = write(STDERR_FILENO, buf + off, n - off);
+        if (w <= 0) break;
+        off += w;
+      }
     }
   }
   // The sink is left open for reuse; it is reset on the next begin.

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,9 +36,11 @@ struct StderrCapture {
 // (saved_fd == -1) and the real stderr is left untouched.
 StderrCapture begin_stderr_capture();
 
-// Restore stderr. If `replay` is true the captured bytes are written back to
-// the real stderr first (so non-OOM diagnostics are never hidden); otherwise
-// they are discarded.
+// Restore stderr. If `replay` is true the captured bytes are then replayed
+// through REprintf — R's message stream, so non-OOM diagnostics are never
+// hidden, reach GUI consoles, and honor sink(). Otherwise they are discarded.
+// Replay happens on the calling (main R) thread; REprintf is not safe
+// elsewhere.
 void end_stderr_capture(StderrCapture &cap, bool replay);
 
 // Write `msg` (followed by a newline) to R's stderr, but only when the

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,11 +36,9 @@ struct StderrCapture {
 // (saved_fd == -1) and the real stderr is left untouched.
 StderrCapture begin_stderr_capture();
 
-// Restore stderr. If `replay` is true the captured bytes are then replayed
-// through REprintf — R's message stream, so non-OOM diagnostics are never
-// hidden, reach GUI consoles, and honor sink(). Otherwise they are discarded.
-// Replay happens on the calling (main R) thread; REprintf is not safe
-// elsewhere.
+// Restore stderr. If `replay` is true the captured bytes are written back to
+// the real stderr first (so non-OOM diagnostics are never hidden); otherwise
+// they are discarded.
 void end_stderr_capture(StderrCapture &cap, bool replay);
 
 // Write `msg` (followed by a newline) to R's stderr, but only when the


### PR DESCRIPTION
R CMD check flagged the `stderr` symbol in utils.o. Replace the fflush(stderr) calls with fflush(nullptr) (flushes all output streams, so the pre/post-redirect semantics are unchanged) and replay captured XLA diagnostics through REprintf instead of raw fd-2 writes, so they go through R's connections: visible in GUI consoles and divertible via sink().