### PR TITLE
ci: pin anvl remote to dim->axis fix (r-xla/anvl#406)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests:
     testthat (>= 3.0.0),
     xml2
 Remotes:
-    r-xla/anvl
+    r-xla/anvl#406
 LinkingTo:
     Rcpp,
     testthat


### PR DESCRIPTION
tengen renamed ndims()/dims to naxes()/axes, which breaks building anvl@main and with it every R-CMD-check job at the dependency installation step. Point the anvl remote at its fix PR until r-xla/anvl#406 is merged.