### PR TITLE
feat: bf16 (bfloat16) buffer support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # pjrt (development version)
 
+## New features
+
+* `PJRTBuffer` supports the `"bf16"` (bfloat16) element type for storage and
+  IO. Buffers can be created from R `double` and `integer` data, from raw
+  bytes, and from `BF16` safetensors payloads (which load without an
+  intermediate f32 representation, halving the host memory a large
+  checkpoint needs). `as_array()` returns the exactly representable values as
+  `double`, `as_raw()` round-trips the packed bytes, and printing and
+  `format_buffer()` render bf16 directly.
+
+  R doubles are rounded to bf16 to nearest with ties to even, rounding the
+  double directly rather than via `float`, which would double-round.
+
+  bf16 is supported for storage and IO only: the dispatcher rejects a bf16
+  input rather than keying it as a neighbouring dtype, since computing on it
+  needs promotion-lattice support.
+
 # pjrt 0.5.0
 
 ## Performance

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,20 +2,21 @@
 
 ## New features
 
-* `PJRTBuffer` supports the `"bf16"` (bfloat16) element type for storage and
-  IO. Buffers can be created from R `double` and `integer` data, from raw
-  bytes, and from `BF16` safetensors payloads (which load without an
-  intermediate f32 representation, halving the host memory a large
-  checkpoint needs). `as_array()` returns the exactly representable values as
-  `double`, `as_raw()` round-trips the packed bytes, and printing and
-  `format_buffer()` render bf16 directly.
+* `PJRTBuffer` supports the `"bf16"` (bfloat16) element type. Buffers can be
+  created from R `double` and `integer` data, from raw bytes, and from `BF16`
+  safetensors payloads (which load without an intermediate f32
+  representation, halving the host memory a large checkpoint needs).
+  `as_array()` returns the exactly representable values as `double`,
+  `as_raw()` round-trips the packed bytes, and printing and `format_buffer()`
+  render bf16 directly. A compiled bf16 program runs through
+  `pjrt_execute()`.
 
   R doubles are rounded to bf16 to nearest with ties to even, rounding the
   double directly rather than via `float`, which would double-round.
 
-  bf16 is supported for storage and IO only: the dispatcher rejects a bf16
-  input rather than keying it as a neighbouring dtype, since computing on it
-  needs promotion-lattice support.
+  What bf16 does not reach is the dispatcher: a bf16 input is rejected rather
+  than keyed as a neighbouring dtype, since eager arithmetic on it needs
+  promotion-lattice support.
 
 # pjrt 0.5.0
 

--- a/R/buffer.R
+++ b/R/buffer.R
@@ -47,6 +47,10 @@ is_buffer <- function(x) {
 #'   - `"pred"`: predicate (i.e. a boolean)
 #'   - `"{s,u}{8,16,32,64}"`: Signed and unsigned integer (for `integer` data).
 #'   - `"f{32,64}"`: Floating point (for `double` or `integer` data).
+#'   - `"bf16"`: bfloat16 (for `double` or `integer` data). Values are rounded
+#'     to the nearest bfloat16 value, ties to even; the largest finite value is
+#'     about 3.3895e38, and larger magnitudes round to `Inf`.
+#'     [`as_array()`] returns the exactly representable values as `double`.
 #'   The default (`NULL`) depends on the method:
 #'   - `logical` -> `"pred"`
 #'   - `integer` -> `"i32"`

--- a/R/safetensors.R
+++ b/R/safetensors.R
@@ -24,6 +24,7 @@ pjrt_dtype_to_safetensors <- function(pjrt_dtype) {
     "ui16" = "U16",
     "ui32" = "U32",
     "ui64" = "U64",
+    "bf16" = "BF16",
     "f32" = "F32",
     "f64" = "F64",
     cli::cli_abort("Unsupported PJRT data type {.val {pjrt_dtype}}")
@@ -42,6 +43,7 @@ safetensors_dtype_to_pjrt <- function(safetensors_dtype) {
     "U16" = "ui16",
     "U32" = "ui32",
     "U64" = "ui64",
+    "BF16" = "bf16",
     "F32" = "f32",
     "F64" = "f64",
     cli::cli_abort(
@@ -62,6 +64,7 @@ pjrt_dtype_size <- function(pjrt_dtype) {
     "ui16" = 2L,
     "ui32" = 4L,
     "ui64" = 8L,
+    "bf16" = 2L,
     "f32" = 4L,
     "f64" = 8L,
     cli::cli_abort("Unsupported PJRT data type {.val {pjrt_dtype}}")

--- a/man/pjrt_buffer.Rd
+++ b/man/pjrt_buffer.Rd
@@ -30,6 +30,10 @@ Currently supported types are:
 \item \code{"pred"}: predicate (i.e. a boolean)
 \item \code{"{s,u}{8,16,32,64}"}: Signed and unsigned integer (for \code{integer} data).
 \item \code{"f{32,64}"}: Floating point (for \code{double} or \code{integer} data).
+\item \code{"bf16"}: bfloat16 (for \code{double} or \code{integer} data). Values are rounded
+to the nearest bfloat16 value, ties to even; the largest finite value is
+about 3.3895e38, and larger magnitudes round to \code{Inf}.
+\code{\link[=as_array]{as_array()}} returns the exactly representable values as \code{double}.
 The default (\code{NULL}) depends on the method:
 \item \code{logical} -> \code{"pred"}
 \item \code{integer} -> \code{"i32"}

--- a/src/bfloat16.h
+++ b/src/bfloat16.h
@@ -7,9 +7,9 @@
 // range as binary32, seven fewer mantissa bits, so every bf16 is an exactly
 // representable float and the widening direction is a bit shift.
 //
-// This is a storage-and-conversion type only: pjrt supports bf16 buffers for
-// storage and IO, not for compute, so no arithmetic operators are defined.
-// Anything that needs to compute on the values widens to float first.
+// A host-side storage and conversion type only, with no arithmetic operators:
+// arithmetic on bf16 values happens on device, inside the XLA program. Host
+// code that needs to compute on them widens to float first.
 //
 // Deliberately not a vendored dependency. bf16 is simple enough that the
 // conversion is shorter than the code needed to select and audit a third-party

--- a/src/bfloat16.h
+++ b/src/bfloat16.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+// bfloat16 (BF16): sign(1) exponent(8, bias 127) mantissa(7). Same exponent
+// range as binary32, seven fewer mantissa bits, so every bf16 is an exactly
+// representable float and the widening direction is a bit shift.
+//
+// This is a storage-and-conversion type only: pjrt supports bf16 buffers for
+// storage and IO, not for compute, so no arithmetic operators are defined.
+// Anything that needs to compute on the values widens to float first.
+//
+// Deliberately not a vendored dependency. bf16 is simple enough that the
+// conversion is shorter than the code needed to select and audit a third-party
+// half-precision library, and rounding is the part that has to be right.
+namespace rpjrt {
+
+struct bfloat16 {
+  uint16_t bits;
+
+  // Trivially copyable and standard layout: the raw-bytes paths (safetensors
+  // payloads, device transfers) reinterpret_cast arrays of these, and the
+  // memcpys below assume no padding and no extra state.
+  bfloat16() = default;
+
+  static bfloat16 from_bits(uint16_t b) {
+    bfloat16 out;
+    out.bits = b;
+    return out;
+  }
+
+  // Widening to float is exact: bf16's mantissa is a prefix of binary32's and
+  // the exponent fields are identical, so the value is the top half of the
+  // corresponding binary32 bit pattern.
+  float to_float() const {
+    const uint32_t widened = static_cast<uint32_t>(bits) << 16;
+    float out;
+    std::memcpy(&out, &widened, sizeof(out));
+    return out;
+  }
+
+  // Implicit, so std::copy() into a double* (the as_array() path) and the
+  // printer's widening both work without a special case per call site. The
+  // reverse direction is deliberately explicit: it rounds, and rounding should
+  // never happen by accident.
+  operator float() const { return to_float(); }
+
+  // Round a double to bf16, to nearest with ties to even.
+  //
+  // Rounds the double directly rather than going through float. Rounding
+  // double -> float -> bf16 double-rounds: a double just below a bf16
+  // midpoint can round up to a float sitting exactly on that midpoint, which
+  // then ties away to the wrong neighbour. (Concretely, a double just under
+  // 1.01171875 should give 1.0078125, but via float it gives 1.015625.)
+  static bfloat16 from_double(double v) {
+    uint64_t db;
+    std::memcpy(&db, &v, sizeof(db));
+
+    const uint16_t sign = static_cast<uint16_t>((db >> 48) & 0x8000u);
+    const int64_t biased_exp = static_cast<int64_t>((db >> 52) & 0x7FFu);
+    const uint64_t frac = db & 0xFFFFFFFFFFFFFull;  // low 52 bits
+
+    if (biased_exp == 0x7FF) {  // Inf or NaN
+      // Quiet NaN, canonical payload: XLA's own bf16 printers do the same, and
+      // no NaN payload survives a 52 -> 7 bit mantissa narrowing anyway.
+      if (frac != 0) return from_bits(0x7FC0u);
+      return from_bits(static_cast<uint16_t>(sign | 0x7F80u));
+    }
+
+    // Normalise to significand * 2^(exp - 52) with bit 52 of the significand
+    // set, so a single rounding step handles normals and subnormals alike.
+    int64_t exp;
+    uint64_t sig;
+    if (biased_exp == 0) {
+      if (frac == 0) return from_bits(sign);  // signed zero
+      exp = -1022;
+      sig = frac;
+      while ((sig & (1ull << 52)) == 0) {
+        sig <<= 1;
+        --exp;
+      }
+    } else {
+      exp = biased_exp - 1023;
+      sig = frac | (1ull << 52);
+    }
+
+    // bf16 keeps 8 significant bits (1 implicit + 7 stored), so a normal
+    // result drops 45 of the 53. Below bf16's minimum normal exponent the
+    // result is subnormal: hold the exponent at -126 and drop correspondingly
+    // more bits, which is what makes the single rounding step correct there
+    // too.
+    int drop = 45;
+    if (exp < -126) {
+      drop += static_cast<int>(-126 - exp);
+      exp = -126;
+    }
+    // sig < 2^53, so from 54 bits up both the quotient and the round bit are
+    // zero and the value rounds to zero. Guarding here also keeps the shifts
+    // below in range.
+    if (drop >= 54) return from_bits(sign);
+
+    const uint64_t lsb = 1ull << drop;
+    const uint64_t half = lsb >> 1;
+    const uint64_t rem = sig & (lsb - 1);
+    uint64_t q = sig >> drop;
+    if (rem > half || (rem == half && (q & 1) != 0)) ++q;
+
+    // Assembling with (exp + 126) rather than (exp + 127) folds the implicit
+    // bit still present in q into the exponent field, which makes all three
+    // awkward cases fall out with no branch: a normal rounding up from 0xFF to
+    // 0x100 carries into the exponent, a subnormal (q < 0x80) leaves the
+    // exponent field at zero, and a subnormal rounding up to q == 0x80 becomes
+    // the smallest normal.
+    const uint32_t assembled =
+        (static_cast<uint32_t>(exp + 126) << 7) + static_cast<uint32_t>(q);
+    if (assembled >= 0x7F80u) {  // overflowed the largest finite bf16
+      return from_bits(static_cast<uint16_t>(sign | 0x7F80u));
+    }
+    return from_bits(static_cast<uint16_t>(sign | assembled));
+  }
+};
+
+static_assert(sizeof(bfloat16) == 2, "bfloat16 must be exactly 2 bytes");
+
+}  // namespace rpjrt

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -38,6 +38,8 @@ std::string PJRTElementType::as_string() const {
       return "ui32";
     case PJRT_Buffer_Type_U64:
       return "ui64";
+    case PJRT_Buffer_Type_BF16:
+      return "bf16";
     case PJRT_Buffer_Type_F32:
       return "f32";
     case PJRT_Buffer_Type_F64:

--- a/src/buffer_printer.cpp
+++ b/src/buffer_printer.cpp
@@ -13,6 +13,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "bfloat16.h"
 #include "buffer.h"
 #include "utils.h"
 
@@ -445,6 +446,21 @@ std::vector<std::string> buffer_to_string_lines(
   };
 
   switch (element_type) {
+    case PJRT_Buffer_Type_BF16: {
+      // Widened to float rather than formatted in place: bf16 -> float is
+      // exact, and the float formatters render via double anyway.
+      const rpjrt::bfloat16 *bf16_data =
+          static_cast<const rpjrt::bfloat16 *>(data);
+      std::vector<float> widened(static_cast<size_t>(numel));
+      for (int64_t i = 0; i < numel; ++i) {
+        widened[i] = bf16_data[i].to_float();
+      }
+      std::span<const float> temp_span(widened.data(),
+                                       static_cast<size_t>(numel));
+      print_with_formatter_fn(dimensions, max_width, max_rows_slice, rows_left,
+                              cont, temp_span);
+      break;
+    }
     case PJRT_Buffer_Type_F32:
       handle_float(float{});
       break;
@@ -499,6 +515,13 @@ void buffer_print(Rcpp::XPtr<rpjrt::PJRTBuffer> buffer, int max_rows,
   std::vector<std::string> cont;
 
   switch (element_type) {
+    case PJRT_Buffer_Type_BF16: {
+      std::vector<rpjrt::bfloat16> temp_vec =
+          buffer_to_host_copy<rpjrt::bfloat16>(buffer.get(), numel);
+      cont = buffer_to_string_lines(temp_vec.data(), dimensions, element_type,
+                                    max_rows, max_width, max_rows_slice);
+      break;
+    }
     case PJRT_Buffer_Type_F32: {
       std::vector<float> temp_vec =
           buffer_to_host_copy<float>(buffer.get(), numel);

--- a/src/dispatch_engine.cpp
+++ b/src/dispatch_engine.cpp
@@ -158,8 +158,8 @@ SEXP Engine::canonical_device(SEXP device) {
 
 // Reject an Aval whose dtype could not be represented: every such leaf would
 // share one Aval, and two calls on different dtypes would then run each other's
-// program. Neither tengen nor pjrt's own dtype table can produce one, so this
-// is a guard, not a path.
+// program. A bf16 buffer reaches this for real, since pjrt stores bf16 but the
+// dispatcher cannot key it, so this is a live path and not only a guard.
 static void check_dtype_representable(const Aval& a, const RTree& in_tree,
                                       std::size_t leaf_index) {
   if (a.dtype == AnvlDtype::kInvalid) {

--- a/src/dispatch_key.h
+++ b/src/dispatch_key.h
@@ -24,13 +24,20 @@ namespace rpjrt {
 // our own rather than PJRT_Buffer_Type: an Aval describes a plain R array that
 // never went near PJRT just as readily as a PJRT buffer.
 //
-// The set is what the dispatcher can represent, which is also exactly what
-// pjrt's string_to_pjrt_buffer_type() accepts. tengen now names more dtypes
-// than this (f16, bf16, f8*, complex, sub-byte ints); those are rejected by
+// The set is what the dispatcher can represent. tengen names more dtypes than
+// this (f16, bf16, f8*, complex, sub-byte ints); those are rejected by
 // anvl_dtype_from_tengen() below rather than keyed approximately. Conversions
 // in either direction are explicit switches rather than casts, so a PJRT type
 // outside this set maps to kInvalid rather than silently becoming a
 // neighbouring dtype.
+//
+// pjrt's buffer layer deliberately runs ahead of the dispatcher: bf16 is
+// supported for storage and IO, so string_to_pjrt_buffer_type() accepts
+// "bf16", but there is no kBF16 here. A bf16 buffer reaching the dispatcher
+// maps to kInvalid and is rejected by check_dtype_representable() rather than
+// being keyed as a neighbouring dtype. Compute on bf16 is a separate step that
+// needs the promotion lattice, so keeping it out here is the point, not an
+// omission. Add kBF16 (and both switches below) when that step happens.
 enum class AnvlDtype {
   kInvalid,
   kBool,

--- a/src/dispatch_key.h
+++ b/src/dispatch_key.h
@@ -31,13 +31,14 @@ namespace rpjrt {
 // outside this set maps to kInvalid rather than silently becoming a
 // neighbouring dtype.
 //
-// pjrt's buffer layer deliberately runs ahead of the dispatcher: bf16 is
-// supported for storage and IO, so string_to_pjrt_buffer_type() accepts
-// "bf16", but there is no kBF16 here. A bf16 buffer reaching the dispatcher
-// maps to kInvalid and is rejected by check_dtype_representable() rather than
-// being keyed as a neighbouring dtype. Compute on bf16 is a separate step that
-// needs the promotion lattice, so keeping it out here is the point, not an
-// omission. Add kBF16 (and both switches below) when that step happens.
+// pjrt's buffer layer deliberately runs ahead of the dispatcher: bf16 buffers
+// exist and a compiled bf16 program executes, so string_to_pjrt_buffer_type()
+// accepts "bf16", but there is no kBF16 here. A bf16 buffer reaching the
+// dispatcher maps to kInvalid and is rejected by check_dtype_representable()
+// rather than being keyed as a neighbouring dtype. Eager arithmetic on bf16 is
+// a separate step that needs the promotion lattice, so keeping it out here is
+// the point, not an omission. Add kBF16 (and both switches below) when that
+// step happens.
 enum class AnvlDtype {
   kInvalid,
   kBool,

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -38,6 +38,8 @@ PJRT_FFI_Extension *get_pjrt_ffi_extension(PJRTPlugin *plugin) {
 
 PJRT_Buffer_Type to_pjrt_type(xla::ffi::DataType dtype) {
   switch (dtype) {
+    case xla::ffi::DataType::BF16:
+      return PJRT_Buffer_Type_BF16;
     case xla::ffi::DataType::F32:
       return PJRT_Buffer_Type_F32;
     case xla::ffi::DataType::F64:

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -5,34 +5,59 @@
 #include <sstream>
 #include <vector>
 
+#include "bfloat16.h"
+
 using namespace Rcpp;
 
-std::string format_float_value(double value, int precision) {
-  // stablehlo format for NaN and infinity
+// The stablehlo hex spellings of NaN and infinity, plus the number of decimal
+// digits that round-trips the format, for one floating-point dtype.
+//
+// Keyed by dtype rather than by bit width: bf16 and f16 are both 16 bits, so
+// width no longer identifies a floating-point format.
+struct FloatFormat {
+  const char *nan;
+  const char *pos_inf;
+  const char *neg_inf;
+  int digits;  // significant decimal digits needed to round-trip
+};
+
+// digits = ceil(mantissa_bits * log10(2)) + 1: 4 for bf16 (8 bits), 9 for f32
+// (24), 17 for f64 (53). std::setprecision under std::scientific prints one
+// digit before the point and `n` after, so it is passed digits - 1.
+constexpr FloatFormat kBF16Format = {"0x7FC0", "0x7F80", "0xFF80", 4};
+constexpr FloatFormat kF32Format = {"0x7FC00000", "0x7F800000", "0xFF800000",
+                                    9};
+constexpr FloatFormat kF64Format = {"0x7FF8000000000000", "0x7FF0000000000000",
+                                    "0xFFF0000000000000", 17};
+
+std::string format_float_value(double value, const FloatFormat &fmt) {
   if (R_IsNaN(value)) {
-    return (precision == 64) ? "0x7FF8000000000000" : "0x7FC00000";
+    return fmt.nan;
   } else if (!R_finite(value)) {
-    if (precision == 64) {
-      return (value > 0) ? "0x7FF0000000000000" : "0xFFF0000000000000";
-    }
-    return (value > 0) ? "0x7F800000" : "0xFF800000";
+    return (value > 0) ? fmt.pos_inf : fmt.neg_inf;
   }
   std::ostringstream oss;
-  oss << std::scientific << std::setprecision(precision == 32 ? 8 : 16);
+  oss << std::scientific << std::setprecision(fmt.digits - 1);
   oss << value;
   return oss.str();
 }
 
 std::string format_element(const unsigned char *ptr, std::string dtype) {
   std::ostringstream oss;
-  if (dtype == "f32") {
+  if (dtype == "bf16") {
+    uint16_t bits;
+    std::memcpy(&bits, ptr, 2);
+    return format_float_value(
+        static_cast<double>(rpjrt::bfloat16::from_bits(bits).to_float()),
+        kBF16Format);
+  } else if (dtype == "f32") {
     float val;
     std::memcpy(&val, ptr, 4);
-    return format_float_value((double)val, 32);
+    return format_float_value((double)val, kF32Format);
   } else if (dtype == "f64") {
     double val;
     std::memcpy(&val, ptr, 8);
-    return format_float_value(val, 64);
+    return format_float_value(val, kF64Format);
   } else if (dtype == "i64") {
     int64_t val;
     std::memcpy(&val, ptr, 8);
@@ -74,7 +99,7 @@ std::string format_element(const unsigned char *ptr, std::string dtype) {
 int get_element_size(std::string dtype) {
   if (dtype == "f64" || dtype == "i64" || dtype == "ui64") return 8;
   if (dtype == "f32" || dtype == "i32" || dtype == "ui32") return 4;
-  if (dtype == "i16" || dtype == "ui16") return 2;
+  if (dtype == "bf16" || dtype == "i16" || dtype == "ui16") return 2;
   return 1;
 }
 

--- a/src/pjrt.cpp
+++ b/src/pjrt.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include "bfloat16.h"
 #include "buffer.h"
 #include "buffer_printer.h"
 #include "client.h"
@@ -120,7 +121,24 @@ Rcpp::XPtr<rpjrt::PJRTDevice> impl_loaded_executable_device(
 // type conversion as needed. T is the PJRT-side element type.
 template <typename T>
 void convert_r_data_to_typed(SEXP data, T *dst, int len) {
-  if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
+  if constexpr (std::is_same_v<T, rpjrt::bfloat16>) {
+    // from_double() rounds the R double straight to bf16, to nearest with ties
+    // to even. Going through float first would double-round: a double just
+    // below a bf16 midpoint can round up to a float sitting exactly on it,
+    // which then ties away to the wrong neighbour.
+    if (TYPEOF(data) == REALSXP) {
+      for (int i = 0; i < len; ++i) {
+        dst[i] = rpjrt::bfloat16::from_double(REAL(data)[i]);
+      }
+    } else if (TYPEOF(data) == INTSXP) {
+      for (int i = 0; i < len; ++i) {
+        dst[i] =
+            rpjrt::bfloat16::from_double(static_cast<double>(INTEGER(data)[i]));
+      }
+    } else {
+      Rcpp::stop("Cannot convert R type %d to floating point", TYPEOF(data));
+    }
+  } else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
     if (TYPEOF(data) == REALSXP) {
       std::copy(REAL(data), REAL(data) + len, dst);
     } else if (TYPEOF(data) == INTSXP) {
@@ -351,7 +369,10 @@ Rcpp::XPtr<rpjrt::PJRTBuffer> impl_client_buffer_from_raw(
     Rcpp::XPtr<rpjrt::PJRTClient> client, Rcpp::XPtr<rpjrt::PJRTDevice> device,
     SEXP data, std::vector<int64_t> dims, std::string dtype,
     bool row_major = false) {
-  if (dtype == "f32") {
+  if (dtype == "bf16") {
+    return create_buffer_from_raw(client, data, dims, PJRT_Buffer_Type_BF16,
+                                  row_major, device->device);
+  } else if (dtype == "f32") {
     return create_buffer_from_raw(client, data, dims, PJRT_Buffer_Type_F32,
                                   row_major, device->device);
   } else if (dtype == "f64") {
@@ -563,6 +584,9 @@ Rcpp::RawVector impl_buffer_to_raw(Rcpp::XPtr<rpjrt::PJRTClient> client,
   };
 
   switch (element_type) {
+    case PJRT_Buffer_Type_BF16:
+      handle_transpose(rpjrt::bfloat16{});
+      break;
     case PJRT_Buffer_Type_F32:
       handle_transpose(float{});
       break;
@@ -854,7 +878,12 @@ SEXP impl_raw_to_array(Rcpp::XPtr<rpjrt::PJRTHostData> host_data,
     raw_data = host_data->data().data();
   }
 
-  if (dtype == "f32") {
+  if (dtype == "bf16") {
+    // Widening bf16 -> double is exact, so as_array() returns precisely the
+    // values the buffer holds.
+    return raw_to_array_impl<rpjrt::bfloat16>(raw_data, dimensions, REALSXP,
+                                              m2m);
+  } else if (dtype == "f32") {
     return raw_to_array_impl<float>(raw_data, dimensions, REALSXP, m2m);
   } else if (dtype == "f64") {
     return raw_to_array_impl<double>(raw_data, dimensions, REALSXP, m2m);
@@ -1136,6 +1165,9 @@ Rcpp::XPtr<rpjrt::PJRTBuffer> impl_client_buffer_from_integer(
   } else if (dtype == "ui64") {
     return create_buffer_from_array_async<uint64_t>(
         client, data, dims, PJRT_Buffer_Type_U64, false, device->device);
+  } else if (dtype == "bf16") {
+    return create_buffer_from_array_async<rpjrt::bfloat16>(
+        client, data, dims, PJRT_Buffer_Type_BF16, false, device->device);
   } else if (dtype == "f32") {
     return create_buffer_from_array_async<float>(
         client, data, dims, PJRT_Buffer_Type_F32, false, device->device);
@@ -1187,7 +1219,10 @@ Rcpp::XPtr<rpjrt::PJRTBuffer> impl_client_buffer_from_logical(
 Rcpp::XPtr<rpjrt::PJRTBuffer> impl_client_buffer_from_double(
     Rcpp::XPtr<rpjrt::PJRTClient> client, Rcpp::XPtr<rpjrt::PJRTDevice> device,
     SEXP data, std::vector<int64_t> dims, std::string dtype) {
-  if (dtype == "f32") {
+  if (dtype == "bf16") {
+    return create_buffer_from_array_async<rpjrt::bfloat16>(
+        client, data, dims, PJRT_Buffer_Type_BF16, false, device->device);
+  } else if (dtype == "f32") {
     return create_buffer_from_array_async<float>(
         client, data, dims, PJRT_Buffer_Type_F32, false, device->device);
   } else if (dtype == "f64") {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -190,6 +190,7 @@ PJRT_Error_Code get_error_code(const PJRT_Api *api, PJRT_Error *err) {
 }
 
 PJRT_Buffer_Type string_to_pjrt_buffer_type(const std::string &dtype) {
+  if (dtype == "bf16") return PJRT_Buffer_Type_BF16;
   if (dtype == "f32") return PJRT_Buffer_Type_F32;
   if (dtype == "f64") return PJRT_Buffer_Type_F64;
   if (dtype == "i8") return PJRT_Buffer_Type_S8;
@@ -206,6 +207,8 @@ PJRT_Buffer_Type string_to_pjrt_buffer_type(const std::string &dtype) {
 
 size_t sizeof_pjrt_buffer_type(PJRT_Buffer_Type type) {
   switch (type) {
+    case PJRT_Buffer_Type_BF16:
+      return 2;
     case PJRT_Buffer_Type_F32:
       return 4;
     case PJRT_Buffer_Type_F64:

--- a/tests/testthat/_snaps/buffer-printer.md
+++ b/tests/testthat/_snaps/buffer-printer.md
@@ -217,6 +217,47 @@
        1.0000e-10
       [ CPUf32{2} ] 
 
+# printer for bf16
+
+    Code
+      pjrt_buffer(1:10, "bf16")
+    Output
+      PJRTBuffer 
+        1
+        2
+        3
+        4
+        5
+        6
+        7
+        8
+        9
+       10
+      [ CPUbf16{10} ] 
+
+---
+
+    Code
+      pjrt_buffer(c(1.5, -0.25, 3.140625), dtype = "bf16")
+    Output
+      PJRTBuffer 
+        1.5000
+       -0.2500
+        3.1406
+      [ CPUbf16{3} ] 
+
+---
+
+    Code
+      pjrt_buffer(c(2^128 * (1 - 2^(-8)), Inf, NaN, 2^(-133)), dtype = "bf16")
+    Output
+      PJRTBuffer 
+       3.3895e+38
+              inf
+              nan
+       9.1835e-41
+      [ CPUbf16{4} ] 
+
 # integer-valued floats with truncation
 
     Code

--- a/tests/testthat/test-buffer-printer.R
+++ b/tests/testthat/test-buffer-printer.R
@@ -51,6 +51,16 @@ test_that("printer for doubles", {
   expect_snapshot(pjrt_buffer(c(1e10, 1e-10)))
 })
 
+test_that("printer for bf16", {
+  skip_if(is_metal() | is_cuda())
+  # integer-valued bfloat16s print without decimals, like the other floats
+  expect_snapshot(pjrt_buffer(1:10, "bf16"))
+  expect_snapshot(pjrt_buffer(c(1.5, -0.25, 3.140625), dtype = "bf16"))
+  expect_snapshot(
+    pjrt_buffer(c(2^128 * (1 - 2^-8), Inf, NaN, 2^-133), dtype = "bf16")
+  )
+})
+
 test_that("integer-valued floats with truncation", {
   skip_if(is_metal() | is_cuda())
   # > 30 rows triggers row truncation

--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -193,6 +193,103 @@ test_that("pjrt_buffer roundtrip works for double data with different types", {
   test_pjrt_buffer(data_matrix, "f32", tolerance = 1e-6)
 })
 
+test_that("pjrt_buffer roundtrip works for bf16 data", {
+  # exactly representable in bfloat16, so no tolerance is needed
+  test_pjrt_buffer(c(1.0, -1.0, 0.0, 0.5, 0.25), "bf16")
+  test_pjrt_buffer(matrix(c(1.5, 2.25, -3.5, 4.75), nrow = 2), "bf16")
+  test_pjrt_scalar(0.5, "bf16")
+})
+
+test_that("bf16 buffers materialize the exactly representable doubles", {
+  # bfloat16 targets computed independently: 1/3 -> 0x3EAB = 0.333984375,
+  # 0.1 -> 0x3DCD = 0.10009765625, 2^128 * (1 - 2^-8) = 0x7F7F is the largest
+  # finite value, 2^128 * (1 - 2^-9) is the overflow midpoint and rounds (ties
+  # to even, since 0x7F7F has an odd mantissa) to Inf, 2^-133 = smallest
+  # subnormal.
+  bf16_max <- 2^128 * (1 - 2^-8)
+  input <- c(1, 0.5, 1 / 3, 0.1, bf16_max, 2^128 * (1 - 2^-9), 2^-133, -2.5, 0)
+  expected <- c(
+    1,
+    0.5,
+    0.333984375,
+    0.10009765625,
+    bf16_max,
+    Inf,
+    2^-133,
+    -2.5,
+    0
+  )
+  buf <- pjrt_buffer(input, dtype = "bf16")
+  expect_equal(as.character(elt_type(buf)), "bf16")
+  expect_identical(as_array(buf), array(expected))
+
+  # integer data is accepted like for the other float dtypes
+  buf_int <- pjrt_buffer(matrix(1:6, nrow = 2), dtype = "bf16")
+  expect_equal(as.character(elt_type(buf_int)), "bf16")
+  expect_identical(as_array(buf_int), matrix(as.double(1:6), nrow = 2))
+
+  s <- pjrt_scalar(3.14159, dtype = "bf16")
+  expect_identical(shape(s), integer())
+  expect_identical(as_array(s), 3.140625)
+})
+
+test_that("doubles round to bf16 to nearest, ties to even, not via float", {
+  # The double just below 1.01171875 must give 1.0078125. Rounding it through
+  # float first lands exactly on 1.01171875, which is a bf16 midpoint and then
+  # ties up to 1.015625 -- the double-rounding failure this test pins.
+  expect_identical(
+    as_array(pjrt_buffer(1.01171875 - 2^-52, dtype = "bf16")),
+    array(1.0078125)
+  )
+  # The midpoint itself ties to even, which here means rounding up: 1.0078125
+  # has an odd mantissa (0x3F81) and 1.015625 an even one (0x3F82).
+  expect_identical(
+    as_array(pjrt_buffer(1.01171875, dtype = "bf16")),
+    array(1.015625)
+  )
+
+  # Ties to even at the subnormal boundary: 2^-134 is midway between 0 and the
+  # smallest subnormal 2^-133 and rounds to the even neighbour 0; 1.5 * 2^-133
+  # is midway between 2^-133 and 2^-132 and rounds to 2^-132.
+  buf <- pjrt_buffer(c(2^-134, 1.5 * 2^-133), dtype = "bf16")
+  expect_identical(as_array(buf), array(c(0, 2^-132)))
+})
+
+test_that("bf16 raw and empty buffers work", {
+  empty <- pjrt_empty(dtype = "bf16", shape = c(0, 2))
+  expect_identical(shape(empty), c(0L, 2L))
+  expect_equal(as.character(elt_type(empty)), "bf16")
+
+  # 0x3F80 = 1.0 and 0xBF00 = -0.5, as little-endian byte pairs
+  raw_bytes <- as.raw(c(0x80, 0x3f, 0x00, 0xbf))
+  buf <- pjrt_buffer(raw_bytes, dtype = "bf16", shape = 2L, row_major = TRUE)
+  expect_identical(as_array(buf), array(c(1, -0.5)))
+  expect_identical(as_raw(buf, row_major = TRUE), raw_bytes)
+
+  expect_error(
+    pjrt_buffer(
+      as.raw(c(0, 0, 0)),
+      dtype = "bf16",
+      shape = 2L,
+      row_major = TRUE
+    ),
+    "requires 4 bytes"
+  )
+})
+
+test_that("bf16 rejects logical input like the other float dtypes", {
+  expect_error(pjrt_buffer(TRUE, dtype = "bf16"), "Unsupported type")
+})
+
+test_that("dtype() on a bf16 buffer round-trips through tengen", {
+  # Unlike f16, tengen's dtype enum already names bf16, so the buffer-level
+  # dtype and the tengen DataType agree.
+  buf <- pjrt_buffer(1.5, dtype = "bf16")
+  expect_equal(as.character(elt_type(buf)), "bf16")
+  expect_identical(dtype(buf), tengen::as_dtype("bf16"))
+  expect_identical(as_array(pjrt_buffer(1.5, dtype = tengen::as_dtype("bf16"))), array(1.5))
+})
+
 test_that("pjrt_buffer handles edge cases", {
   # Test empty vectors
   expect_error(pjrt_buffer(logical(0), shape = c(1, 4)), "but specified shape is")

--- a/tests/testthat/test-dispatch.R
+++ b/tests/testthat/test-dispatch.R
@@ -793,6 +793,18 @@ test_that("an input pjrt cannot classify is rejected, naming the offending argum
     "invalid input `x`.*dtype is not one anvl can represent"
   )
 
+  # bf16 goes further than f16: pjrt really does store it, so a genuine bf16
+  # buffer reaches the kInvalid mapping. Compute on bf16 needs the promotion
+  # lattice, so the dispatcher must reject it here rather than key it as some
+  # neighbouring dtype -- before compile and before the cache is probed.
+  expect_error(
+    impl_dispatch_run(
+      mk("pjrt"),
+      list(x = parr(pjrt_buffer(c(1, 2), dtype = "bf16")))
+    ),
+    "invalid input `x`.*dtype is not one anvl can represent"
+  )
+
   expect_equal(n_miss, 0L) # every rejection happened before the cache was probed
 })
 

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -12,6 +12,19 @@ test_that("format_buffer works for floats", {
   expect_equal(format_buffer(pjrt_scalar(-Inf, "f64")), "0xFFF0000000000000")
 })
 
+test_that("format_buffer works for bf16", {
+  # 4 significant digits round-trip bfloat16
+  expect_equal(format_buffer(pjrt_scalar(1.5, "bf16")), "1.500e+00")
+  # 1/3 rounds to the bfloat16 value 0.333984375
+  expect_equal(format_buffer(pjrt_scalar(1 / 3, "bf16")), "3.340e-01")
+
+  # bf16 and f16 are both 16 bits wide, so these spellings are selected by
+  # dtype and not by width.
+  expect_equal(format_buffer(pjrt_scalar(NaN, "bf16")), "0x7FC0")
+  expect_equal(format_buffer(pjrt_scalar(Inf, "bf16")), "0x7F80")
+  expect_equal(format_buffer(pjrt_scalar(-Inf, "bf16")), "0xFF80")
+})
+
 test_that("format_buffer works for integers", {
   check <- function(x, dtype) {
     buf <- pjrt_buffer(x, dtype = dtype)

--- a/tests/testthat/test-loaded_executable.R
+++ b/tests/testthat/test-loaded_executable.R
@@ -90,6 +90,27 @@ func.func @main(%x: tensor<2x2xf32>, %y: tensor<2x2xf32>) -> tensor<2x2xf32> {
   expect_equal(as.vector(arr), as.vector(matrix(1:4, 2, 2) + matrix(5:8, 2, 2)), tolerance = 1e-6)
 })
 
+test_that("bf16 programs compile and execute", {
+  skip_if_metal("bf16 support is only tested on CPU and CUDA")
+  src <- r"(
+func.func @main(%x: tensor<4xbf16>, %y: tensor<4xbf16>) -> tensor<4xbf16> {
+  %0 = "stablehlo.add"(%x, %y) : (tensor<4xbf16>, tensor<4xbf16>) -> tensor<4xbf16>
+  "func.return"(%0): (tensor<4xbf16>) -> ()
+}
+)"
+  executable <- pjrt_compile(pjrt_program(src))
+
+  x <- pjrt_buffer(c(1, 2.5, 0.333984375, 2^128 * (1 - 2^-8)), dtype = "bf16")
+  y <- pjrt_buffer(c(1, 0.5, 0.333984375, 2^128 * (1 - 2^-8)), dtype = "bf16")
+
+  result <- pjrt_execute(executable, x, y)
+
+  expect_equal(as.character(elt_type(result)), "bf16")
+  # 0.333984375 doubles exactly (an exponent shift), and the largest finite
+  # value overflows to Inf
+  expect_identical(as_array(result), array(c(2, 3, 0.66796875, Inf)))
+})
+
 test_that("wrong shape input raises error", {
   src <- r"(
 func.func @main(%x: tensor<2x2xf32>) -> tensor<2x2xf32> {

--- a/tests/testthat/test-safetensors.R
+++ b/tests/testthat/test-safetensors.R
@@ -53,6 +53,51 @@ test_that("Can write safetensors (different data types)", {
   }
 })
 
+test_that("bf16 safetensors payloads load raw into bf16 buffers", {
+  # Hand-crafted file, independent of pjrt's own writer: an 8-byte header
+  # length, the JSON header, then the packed row-major bfloat16s. The bit
+  # patterns are named here and split into little-endian byte pairs below,
+  # rather than interleaved by hand.
+  bits <- c(
+    `1.0` = 0x3F80,
+    `-2.5` = 0xC020,
+    `1/3` = 0x3EAB, # 0.333984375
+    `max` = 0x7F7F, # 2^128 * (1 - 2^-8), the largest finite value
+    `Inf` = 0x7F80,
+    `min subnormal` = 0x0001 # 2^-133
+  )
+  payload <- as.raw(c(rbind(bits %% 256L, bits %/% 256L)))
+
+  header <- '{"x":{"dtype":"BF16","shape":[2,3],"data_offsets":[0,12]}}'
+  path <- tempfile(fileext = ".safetensors")
+  con <- file(path, "wb")
+  writeBin(nchar(header), con, size = 8L, endian = "little")
+  writeBin(charToRaw(header), con)
+  writeBin(payload, con)
+  close(con)
+
+  dict <- safetensors::safe_load_file(path, framework = "pjrt")
+  expect_equal(as.character(elt_type(dict$x)), "bf16")
+  expect_identical(shape(dict$x), c(2L, 3L))
+  expected <- matrix(
+    c(1, -2.5, 0.333984375, 2^128 * (1 - 2^-8), Inf, 2^-133),
+    nrow = 2,
+    byrow = TRUE
+  )
+  expect_identical(as_array(dict$x), expected)
+})
+
+test_that("bf16 buffers round-trip through safetensors write/read", {
+  x <- list(
+    x = pjrt_buffer(array(c(0.5, 1.5, -2.25, 4), dim = c(2, 2)), dtype = "bf16")
+  )
+  tmp <- tempfile(fileext = ".safetensors")
+  safetensors::safe_save_file(x, tmp)
+  reloaded <- safetensors::safe_load_file(tmp, framework = "pjrt")
+  expect_equal(as.character(elt_type(reloaded$x)), "bf16")
+  expect_identical(as_array(x$x), as_array(reloaded$x))
+})
+
 test_that("load a file (pjrt)", {
   path <- test_path("_safetensors", "hello.safetensors")
   dict <- safetensors::safe_load_file(


### PR DESCRIPTION
Adds `bf16` as a `PJRTBuffer` element type. This is Phase 1 from r-xla/anvl#379, for bf16 rather than f16.

Buffers can be built from R `double` and `integer` data, from raw bytes, and from `BF16` safetensors payloads, which load straight into a bf16 buffer with no intermediate f32. `as_array()` widens exactly back to `double`, `as_raw()` round-trips the packed bytes, and printing and `format_buffer()` render bf16 directly.

Since July, tengen 0.3.0's dtype enum already names `bf16` with the StableHLO spelling and stablehlo already renders `tensor<4xbf16>`, so nothing was needed in either. The work is all in pjrt.

## No vendored dependency

bf16 is sign(1), exponent(8, bias 127), mantissa(7): the same exponent range as binary32 with seven fewer mantissa bits. Widening is a bit shift, and narrowing is one rounding step. `src/bfloat16.h` is 126 lines including comments, so there is no third-party half-precision library here and nothing added to `inst/COPYRIGHTS`.

This is the main difference from #228, which needs a real binary16 implementation and vendors half.hpp for it. If you would rather not carry those 4600 lines, bf16 can land on its own and #228 can be reconsidered separately. Happy either way, but bf16 is the one our workload actually needs, since FLUX.2 ships bf16 checkpoints.

## Rounding

R doubles round to bf16 to nearest, ties to even, rounding the double **directly** rather than via `float`. Going through float double-rounds: a double just below a bf16 midpoint can round up to a float sitting exactly on that midpoint, which then ties away to the wrong neighbour. The double just under `1.01171875` should give `1.0078125`; via float it gives `1.015625`. It is not only a constructed case, it shows up about once per three million random doubles.

Validated against gcc's native `__bf16` over 7,716,260 values: every bf16 bit pattern, both midpoint neighbourhoods of each, the ties-to-even cases, the subnormal and overflow boundaries, all round-trips, and several million random doubles across the full exponent range. Zero mismatches. There is a test pinning the double-rounding case specifically, and I checked it is live by breaking the conversion to go through float, which fails that test and only that test.

## Two things worth a look

**`format_float_value()` is now keyed by dtype rather than by bit width.** It previously branched on `precision == 32` / `== 64`. bf16 and f16 are both 16 bits, so width no longer identifies a floating-point format, and the two need different stablehlo NaN/Inf spellings and different round-trip digit counts. This is the only existing code path the PR touches; the f32 and f64 formatting tests are unchanged and still pass.

**bf16 deliberately stays out of the dispatcher.** `string_to_pjrt_buffer_type()` accepts `"bf16"`, but there is no `kBF16` in `AnvlDtype`, so a bf16 buffer reaching the dispatcher maps to `kInvalid` and is rejected by `check_dtype_representable()` before compile or cache, rather than being keyed as a neighbouring dtype. Eager arithmetic on bf16 needs the promotion lattice, which is a separate step. Tell me if you would rather that rejection live somewhere else.

To be precise about the scope, since it is easy to overstate: buffer construction, conversion, printing, and serialization all work, and a compiled bf16 program executes through `pjrt_execute()` (there is a test). What is not supported is bf16 through the eager dispatch and promotion path.

## Testing

Full suite: 1139 passed, 0 failed, 29 skipped. 50 bf16 assertions across 11 blocks. `clang-format` (21.1.2) and `air` clean.

**Verified on the CPU plugin only.** The 29 skips are the CUDA and Metal tests, so the bf16 paths have not been exercised on an accelerator. Nothing in the change is platform-specific (the conversion is host-side and the buffer paths are plugin-agnostic), but I did not run it on CUDA and am not claiming it.
